### PR TITLE
Local persistence xsd 2.0.6

### DIFF
--- a/kundera-core/src/main/java/com/impetus/kundera/loader/PersistenceXMLLoader.java
+++ b/kundera-core/src/main/java/com/impetus/kundera/loader/PersistenceXMLLoader.java
@@ -29,6 +29,11 @@ import javax.persistence.spi.PersistenceUnitTransactionType;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+import javax.xml.validation.Validator;
 
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
@@ -90,19 +95,14 @@ public class PersistenceXMLLoader
 
 			DocumentBuilderFactory docBuilderFactory = null;
 			docBuilderFactory = DocumentBuilderFactory.newInstance();
-			docBuilderFactory.setValidating(true);
 			docBuilderFactory.setNamespaceAware(true);
 
-			try
-			{
-			    // otherwise Xerces fails in validation
-			    docBuilderFactory.setAttribute("http://apache.org/xml/features/validation/schema", true);
-			}
-			catch (IllegalArgumentException e)
-			{
-			    docBuilderFactory.setValidating(false);
-			    docBuilderFactory.setNamespaceAware(false);
-			}
+			final Schema v2Schema = SchemaFactory.newInstance( javax.xml.XMLConstants.W3C_XML_SCHEMA_NS_URI )
+				.newSchema( new StreamSource( getStreamFromClasspath( "persistence_2_0.xsd" ) ) );
+			final Validator v2Validator = v2Schema.newValidator();
+			final Schema v1Schema = SchemaFactory.newInstance( javax.xml.XMLConstants.W3C_XML_SCHEMA_NS_URI )
+				.newSchema( new StreamSource( getStreamFromClasspath( "persistence_1_0.xsd" ) ) );
+			final Validator v1Validator = v1Schema.newValidator();
 
 			InputSource source = new InputSource(is);
 			DocumentBuilder docBuilder = null;
@@ -112,14 +112,30 @@ public class PersistenceXMLLoader
 				// TODO Auto-generated catch block
 				e.printStackTrace();
 			}
-			// docBuilder.setEntityResolver( resolver );
 
 			List errors = new ArrayList();
 			docBuilder.setErrorHandler(new ErrorLogger("XML InputStream", errors));
 			doc = docBuilder.parse(source);
 
-			if (errors.size() != 0)
-			{
+			if (errors.size() == 0) {
+				v2Validator.setErrorHandler( new ErrorLogger("XML InputStream", errors ) );
+				v2Validator.validate( new DOMSource( doc ) );
+				boolean isV1Schema = false;
+				if ( errors.size() != 0 ) {
+					//v2 fails, it could be because the file is v1.
+					Exception exception = (Exception) errors.get( 0 );
+					final String errorMessage = exception.getMessage();
+					//is it a validation error due to a v1 schema validated by a v2
+					isV1Schema = errorMessage.contains("1.0")
+						&& errorMessage.contains("2.0")
+						&& errorMessage.contains("version");
+				}
+				if (isV1Schema) {
+					errors.clear();
+					v1Validator.setErrorHandler( new ErrorLogger("XML InputStream", errors ) );
+					v1Validator.validate( new DOMSource( doc ) );
+				}
+			} else {
 			    throw new InvalidConfigurationException("invalid persistence.xml", (Throwable) errors.get(0));
 			}
 		} catch (IOException e) {
@@ -128,7 +144,7 @@ public class PersistenceXMLLoader
 			throw new InvalidConfigurationException(e);
 		} finally {
 			try {
-				is.close(); // Close input Stream
+				is.close(); 
 			} catch (IOException e) {
 				throw new InvalidConfigurationException(e);
 			}
@@ -136,6 +152,21 @@ public class PersistenceXMLLoader
         
         
         return doc;
+    }
+
+    /**
+     * Get stream from classpath.
+     *
+     * @param fileName 
+     * 		the file name
+     * @return the stream
+     * @throws Exception
+     *             the exception
+     */
+    private static InputStream getStreamFromClasspath(String fileName) {
+	String path = fileName;
+	InputStream dtdStream = PersistenceXMLLoader.class.getClassLoader().getResourceAsStream( path );
+	return dtdStream;
     }
 
     /**

--- a/kundera-core/src/main/resources/persistence_1_0.xsd
+++ b/kundera-core/src/main/resources/persistence_1_0.xsd
@@ -1,0 +1,260 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- persistence.xml schema -->
+<xsd:schema targetNamespace="http://java.sun.com/xml/ns/persistence"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:persistence="http://java.sun.com/xml/ns/persistence"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="1.0">
+
+    <xsd:annotation>
+        <xsd:documentation>
+            @(#)persistence_1_0.xsd 1.0 Feb 9 2006
+        </xsd:documentation>
+    </xsd:annotation>
+    <xsd:annotation>
+        <xsd:documentation><![CDATA[
+
+     This is the XML Schema for the persistence configuration file.
+     The file must be named "META-INF/persistence.xml" in the 
+     persistence archive.
+     Persistence configuration files must indicate
+     the persistence schema by using the persistence namespace:
+
+     http://java.sun.com/xml/ns/persistence
+
+     and indicate the version of the schema by
+     using the version element as shown below:
+
+      <persistence xmlns="http://java.sun.com/xml/ns/persistence"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://java.sun.com/xml/ns/persistence
+          http://java.sun.com/xml/ns/persistence/persistence_1_0.xsd"
+        version="1.0">
+          ...
+      </persistence>
+
+    ]]></xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:simpleType name="versionType">
+        <xsd:restriction base="xsd:token">
+            <xsd:pattern value="[0-9]+(\.[0-9]+)*"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <!-- **************************************************** -->
+
+    <xsd:element name="persistence">
+        <xsd:complexType>
+            <xsd:sequence>
+
+                <!-- **************************************************** -->
+
+                <xsd:element name="persistence-unit"
+                             minOccurs="0" maxOccurs="unbounded">
+                    <xsd:complexType>
+                        <xsd:annotation>
+                            <xsd:documentation>
+
+                                Configuration of a persistence unit.
+
+                            </xsd:documentation>
+                        </xsd:annotation>
+                        <xsd:sequence>
+
+                            <!-- **************************************************** -->
+
+                            <xsd:element name="description" type="xsd:string"
+                                         minOccurs="0">
+                                <xsd:annotation>
+                                    <xsd:documentation>
+
+                                        Textual description of this persistence unit.
+
+                                    </xsd:documentation>
+                                </xsd:annotation>
+                            </xsd:element>
+
+                            <!-- **************************************************** -->
+
+                            <xsd:element name="provider" type="xsd:string"
+                                         minOccurs="0">
+                                <xsd:annotation>
+                                    <xsd:documentation>
+
+                                        Provider class that supplies EntityManagers for this
+                                        persistence unit.
+
+                                    </xsd:documentation>
+                                </xsd:annotation>
+                            </xsd:element>
+
+                            <!-- **************************************************** -->
+
+                            <xsd:element name="jta-data-source" type="xsd:string"
+                                         minOccurs="0">
+                                <xsd:annotation>
+                                    <xsd:documentation>
+
+                                        The container-specific name of the JTA datasource to use.
+
+                                    </xsd:documentation>
+                                </xsd:annotation>
+                            </xsd:element>
+
+                            <!-- **************************************************** -->
+
+                            <xsd:element name="non-jta-data-source" type="xsd:string"
+                                         minOccurs="0">
+                                <xsd:annotation>
+                                    <xsd:documentation>
+
+                                        The container-specific name of a non-JTA datasource to use.
+
+                                    </xsd:documentation>
+                                </xsd:annotation>
+                            </xsd:element>
+
+                            <!-- **************************************************** -->
+
+                            <xsd:element name="mapping-file" type="xsd:string"
+                                         minOccurs="0" maxOccurs="unbounded">
+                                <xsd:annotation>
+                                    <xsd:documentation>
+
+                                        File containing mapping information. Loaded as a resource
+                                        by the persistence provider.
+
+                                    </xsd:documentation>
+                                </xsd:annotation>
+                            </xsd:element>
+
+                            <!-- **************************************************** -->
+
+                            <xsd:element name="jar-file" type="xsd:string"
+                                         minOccurs="0" maxOccurs="unbounded">
+                                <xsd:annotation>
+                                    <xsd:documentation>
+
+                                        Jar file that should be scanned for entities.
+                                        Not applicable to Java SE persistence units.
+
+                                    </xsd:documentation>
+                                </xsd:annotation>
+                            </xsd:element>
+
+                            <!-- **************************************************** -->
+
+                            <xsd:element name="class" type="xsd:string"
+                                         minOccurs="0" maxOccurs="unbounded">
+                                <xsd:annotation>
+                                    <xsd:documentation>
+
+                                        Class to scan for annotations. It should be annotated
+                                        with either @Entity, @Embeddable or @MappedSuperclass.
+
+                                    </xsd:documentation>
+                                </xsd:annotation>
+                            </xsd:element>
+
+                            <!-- **************************************************** -->
+
+                            <xsd:element name="exclude-unlisted-classes" type="xsd:boolean"
+                                         default="false" minOccurs="0">
+                                <xsd:annotation>
+                                    <xsd:documentation>
+
+                                        When set to true then only listed classes and jars will
+                                        be scanned for persistent classes, otherwise the enclosing
+                                        jar or directory will also be scanned. Not applicable to
+                                        Java SE persistence units.
+
+                                    </xsd:documentation>
+                                </xsd:annotation>
+                            </xsd:element>
+
+                            <!-- **************************************************** -->
+
+                            <xsd:element name="properties" minOccurs="0">
+                                <xsd:annotation>
+                                    <xsd:documentation>
+
+                                        A list of vendor-specific properties.
+
+                                    </xsd:documentation>
+                                </xsd:annotation>
+                                <xsd:complexType>
+                                    <xsd:sequence>
+                                        <xsd:element name="property"
+                                                     minOccurs="0" maxOccurs="unbounded">
+                                            <xsd:annotation>
+                                                <xsd:documentation>
+                                                    A name-value pair.
+                                                </xsd:documentation>
+                                            </xsd:annotation>
+                                            <xsd:complexType>
+                                                <xsd:attribute name="name" type="xsd:string"
+                                                               use="required"/>
+                                                <xsd:attribute name="value" type="xsd:string"
+                                                               use="required"/>
+                                            </xsd:complexType>
+                                        </xsd:element>
+                                    </xsd:sequence>
+                                </xsd:complexType>
+                            </xsd:element>
+
+                        </xsd:sequence>
+
+                        <!-- **************************************************** -->
+
+                        <xsd:attribute name="name" type="xsd:string" use="required">
+                            <xsd:annotation>
+                                <xsd:documentation>
+
+                                    Name used in code to reference this persistence unit.
+
+                                </xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:attribute>
+
+                        <!-- **************************************************** -->
+
+                        <xsd:attribute name="transaction-type"
+                                       type="persistence:persistence-unit-transaction-type">
+                            <xsd:annotation>
+                                <xsd:documentation>
+
+                                    Type of transactions used by EntityManagers from this
+                                    persistence unit.
+
+                                </xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:attribute>
+
+                    </xsd:complexType>
+                </xsd:element>
+            </xsd:sequence>
+            <xsd:attribute name="version" type="persistence:versionType"
+                           fixed="1.0" use="required"/>
+        </xsd:complexType>
+    </xsd:element>
+
+    <!-- **************************************************** -->
+
+    <xsd:simpleType name="persistence-unit-transaction-type">
+        <xsd:annotation>
+            <xsd:documentation>
+
+                public enum TransactionType { JTA, RESOURCE_LOCAL };
+
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:token">
+            <xsd:enumeration value="JTA"/>
+            <xsd:enumeration value="RESOURCE_LOCAL"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+</xsd:schema>
+

--- a/kundera-core/src/main/resources/persistence_2_0.xsd
+++ b/kundera-core/src/main/resources/persistence_2_0.xsd
@@ -1,0 +1,227 @@
+<?xml version="1.0" encoding="UTF-8"?> <!-- persistence.xml schema -->
+<xsd:schema targetNamespace="http://java.sun.com/xml/ns/persistence"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:persistence="http://java.sun.com/xml/ns/persistence"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="2.0">
+    <xsd:annotation>
+        <xsd:documentation>
+            @(#)persistence_2_0.xsd 1.0 October 1 2009
+        </xsd:documentation>
+    </xsd:annotation>
+    <xsd:annotation>
+        <xsd:documentation><![CDATA[
+This is the XML Schema for the persistence configuration file. The file must be named "META-INF/persistence.xml" in the persistence archive.
+Persistence configuration files must indicate the persistence schema by using the persistence namespace:
+http://java.sun.com/xml/ns/persistence
+and indicate the version of the schema by using the version element as shown below:
+<persistence xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/persistence
+http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd" version="2.0">
+... </persistence>
+]]></xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleType name="versionType">
+        <xsd:restriction base="xsd:token">
+            <xsd:pattern value="[0-9]+(\.[0-9]+)*"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <!-- **************************************************** -->
+    <xsd:element name="persistence">
+        <xsd:complexType>
+            <xsd:sequence>
+                <!-- **************************************************** -->
+                <xsd:element name="persistence-unit" minOccurs="1" maxOccurs="unbounded">
+                    <xsd:complexType>
+                        <xsd:annotation>
+                            <xsd:documentation>
+                                Configuration of a persistence unit.
+                            </xsd:documentation>
+                        </xsd:annotation>
+                        <xsd:sequence>
+                            <!-- **************************************************** -->
+                            <xsd:element name="description" type="xsd:string" minOccurs="0">
+                                <xsd:annotation>
+                                    <xsd:documentation>
+                                        Description of this persistence unit.
+                                    </xsd:documentation>
+                                </xsd:annotation>
+                            </xsd:element>
+                            <!-- **************************************************** -->
+                            <xsd:element name="provider" type="xsd:string" minOccurs="0">
+                                <xsd:annotation>
+                                    <xsd:documentation>
+                                        Provider class that supplies EntityManagers for this persistence unit.
+                                    </xsd:documentation>
+                                </xsd:annotation>
+                            </xsd:element>
+                            <!-- **************************************************** -->
+                            <xsd:element name="jta-data-source" type="xsd:string" minOccurs="0">
+                                <xsd:annotation>
+                                    <xsd:documentation>
+                                        The container-specific name of the JTA datasource to use.
+                                    </xsd:documentation>
+                                </xsd:annotation>
+                            </xsd:element>
+                            <!-- **************************************************** -->
+                            <xsd:element name="non-jta-data-source" type="xsd:string" minOccurs="0">
+                                <xsd:annotation>
+                                    <xsd:documentation>
+                                        The container-specific name of a non-JTA datasource to use.
+                                    </xsd:documentation>
+                                </xsd:annotation>
+                            </xsd:element>
+                            <!-- **************************************************** -->
+                            <xsd:element name="mapping-file" type="xsd:string" minOccurs="0" maxOccurs="unbounded">
+                                <xsd:annotation>
+                                    <xsd:documentation>
+                                        File containing mapping information. Loaded as a resource by the persistence
+                                        provider.
+                                    </xsd:documentation>
+                                </xsd:annotation>
+                            </xsd:element>
+                            <!-- **************************************************** -->
+                            <xsd:element name="jar-file" type="xsd:string" minOccurs="0" maxOccurs="unbounded">
+                                <xsd:annotation>
+                                    <xsd:documentation>
+                                        Jar file that is to be scanned for managed classes.
+                                    </xsd:documentation>
+                                </xsd:annotation>
+                            </xsd:element>
+                            <!-- **************************************************** -->
+                            <xsd:element name="class" type="xsd:string" minOccurs="0" maxOccurs="unbounded">
+                                <xsd:annotation>
+                                    <xsd:documentation>
+                                        Managed class to be included in the persistence unit and to scan for
+                                        annotations. It should be annotated with either @Entity, @Embeddable or
+                                        @MappedSuperclass.
+                                    </xsd:documentation>
+                                </xsd:annotation>
+                            </xsd:element>
+                            <!-- **************************************************** -->
+                            <xsd:element name="exclude-unlisted-classes"
+                                         type="xsd:boolean"
+                                         default="true"
+                                         minOccurs="0">
+                                <xsd:annotation>
+                                    <xsd:documentation>
+                                        When set to true then only listed classes and jars will be scanned for
+                                        persistent classes, otherwise the enclosing jar or directory will also be
+                                        scanned. Not applicable to Java SE persistence units.
+                                    </xsd:documentation>
+                                </xsd:annotation>
+                            </xsd:element>
+                            <!-- **************************************************** -->
+                            <xsd:element name="shared-cache-mode" type="persistence:persistence-unit-caching-type"
+                                         minOccurs="0">
+                                <xsd:annotation>
+                                    <xsd:documentation>
+                                        Defines whether caching is enabled for the persistence unit if caching is
+                                        supported by the persistence provider. When set to ALL, all entities will be
+                                        cached. When set to NONE, no entities will be cached. When set to
+                                        ENABLE_SELECTIVE, only entities specified as cacheable will be cached. When set
+                                        to
+                                        JSR-317 Final Release
+                                        323 11/10/09
+                                        Sun Microsystems, Inc.
+                                        Entity Packaging
+                                        Java Persistence 2.0, Final Release persistence.xml Schema
+                                        DISABLE_SELECTIVE, entities specified as not cacheable will not be cached. When
+                                        not specified or when set to UNSPECIFIED, provider defaults may apply.
+                                    </xsd:documentation>
+                                </xsd:annotation>
+                            </xsd:element>
+                            <!-- **************************************************** -->
+                            <xsd:element name="validation-mode" type="persistence:persistence-unit-validation-mode-type"
+                                         minOccurs="0">
+                                <xsd:annotation>
+                                    <xsd:documentation>The validation mode to be used for the persistence unit.
+                                    </xsd:documentation>
+                                </xsd:annotation>
+                            </xsd:element>
+                            <!-- **************************************************** -->
+                            <xsd:element name="properties" minOccurs="0">
+                                <xsd:annotation>
+                                    <xsd:documentation>
+                                        A list of standard and vendor-specific properties and hints.
+                                    </xsd:documentation>
+                                </xsd:annotation>
+                                <xsd:complexType>
+                                    <xsd:sequence>
+                                        <xsd:element name="property"
+                                                     minOccurs="0" maxOccurs="unbounded">
+                                            <xsd:annotation>
+                                                <xsd:documentation>A name-value pair.</xsd:documentation>
+                                            </xsd:annotation>
+                                            <xsd:complexType>
+                                                <xsd:attribute name="name" type="xsd:string" use="required"/>
+                                                <xsd:attribute name="value" type="xsd:string" use="required"/>
+                                            </xsd:complexType>
+                                        </xsd:element>
+                                    </xsd:sequence>
+                                </xsd:complexType>
+                            </xsd:element>
+                        </xsd:sequence>
+                        <!-- **************************************************** -->
+                        <xsd:attribute name="name" type="xsd:string" use="required">
+                            <xsd:annotation>
+                                <xsd:documentation>Name used in code to reference this persistence unit.
+                                </xsd:documentation>
+
+                            </xsd:annotation>
+                        </xsd:attribute>
+                        <!-- **************************************************** -->
+                        <xsd:attribute name="transaction-type" type="persistence:persistence-unit-transaction-type">
+                            <xsd:annotation>
+                                <xsd:documentation>
+                                    Type of transactions used by EntityManagers from this persistence unit.
+                                </xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:attribute>
+                    </xsd:complexType>
+                </xsd:element>
+            </xsd:sequence>
+            <xsd:attribute name="version" type="persistence:versionType"
+                           fixed="2.0" use="required"/>
+        </xsd:complexType>
+    </xsd:element>
+    <!-- **************************************************** -->
+    <xsd:simpleType name="persistence-unit-transaction-type">
+        <xsd:annotation>
+            <xsd:documentation>public enum PersistenceUnitTransactionType {JTA, RESOURCE_LOCAL};
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:token">
+            <xsd:enumeration value="JTA"/>
+            <xsd:enumeration value="RESOURCE_LOCAL"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <!-- **************************************************** -->
+    <xsd:simpleType name="persistence-unit-caching-type">
+        <xsd:annotation>
+            <xsd:documentation>
+                public enum SharedCacheMode { ALL, NONE, ENABLE_SELECTIVE, DISABLE_SELECTIVE, UNSPECIFIED};
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:token">
+            <xsd:enumeration value="ALL"/>
+            <xsd:enumeration value="NONE"/>
+            <xsd:enumeration value="ENABLE_SELECTIVE"/>
+            <xsd:enumeration value="DISABLE_SELECTIVE"/>
+            <xsd:enumeration value="UNSPECIFIED"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <!-- **************************************************** -->
+    <xsd:simpleType name="persistence-unit-validation-mode-type">
+        <xsd:annotation>
+            <xsd:documentation>public enum ValidationMode { AUTO, CALLBACK, NONE};
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:token">
+            <xsd:enumeration value="AUTO"/>
+            <xsd:enumeration value="CALLBACK"/>
+            <xsd:enumeration value="NONE"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+</xsd:schema>


### PR DESCRIPTION
Raised to version 2.0.6.

We have had problems loading the persistence_2_0.xsd files from java.sun.com. So this branch includes the v2 and v1 xsd files in the file system and loads them from there. Same as what hibernate-orm does.

Thanks.
