### PR TITLE
Fix date parsing locale issue

### DIFF
--- a/kundera-core/src/main/java/com/impetus/kundera/property/accessor/DateAccessor.java
+++ b/kundera-core/src/main/java/com/impetus/kundera/property/accessor/DateAccessor.java
@@ -172,7 +172,7 @@ public class DateAccessor implements PropertyAccessor<Date>
         {
             try
             {
-                DateFormat formatter = new SimpleDateFormat(p);
+                DateFormat formatter = new SimpleDateFormat(p, Locale.ENGLISH);
                 Date dt = formatter.parse(date);
                 return dt;
             }


### PR DESCRIPTION
I hope this works everywhere, but from what I know
Database systems don't localize their date output.
