### PR TITLE
Downgraded Guava to 13.0.1 because of issues with Java EE 7 containers

### DIFF
--- a/src/kundera-core/pom.xml
+++ b/src/kundera-core/pom.xml
@@ -87,7 +87,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>14.0.1</version>
+			<version>13.0.1</version>
 		</dependency>
 		<dependency>
 			<groupId>javax.transaction</groupId>


### PR DESCRIPTION
Downgraded Guava to 13.0.1 so that it's possible to deploy apps that use Kundera into Java EE 7 containers, such as Glassfish 4. See https://code.google.com/p/guava-libraries/issues/detail?id=1433

Signed-off-by: Paulo Pires pjpires@gmail.com
