### PR TITLE
MongoDBDataHandler.onViaEmbeddable bug with embedded field

### DIFF
--- a/src/kundera-mongo/src/main/java/com/impetus/client/mongodb/MongoDBDataHandler.java
+++ b/src/kundera-mongo/src/main/java/com/impetus/client/mongodb/MongoDBDataHandler.java
@@ -467,11 +467,14 @@ public final class MongoDBDataHandler
             Class embeddedObjectClass = PropertyAccessorHelper.getGenericClass(embeddedField);
 
             embeddedDocumentObject = document.get(((AbstractAttribute) column).getJPAColumnName());
-
-            Collection embeddedCollection = DocumentObjectMapper.getCollectionFromDocumentList(
-                    (BasicDBList) embeddedDocumentObject, embeddedField.getType(), embeddedObjectClass,
-                    embeddable.getAttributes());
-            PropertyAccessorHelper.set(entity, embeddedField, embeddedCollection);
+            
+            if(embeddedDocumentObject != null)
+            {
+                Collection embeddedCollection = DocumentObjectMapper.getCollectionFromDocumentList(
+                        (BasicDBList) embeddedDocumentObject, embeddedField.getType(), embeddedObjectClass,
+                        embeddable.getAttributes());
+                PropertyAccessorHelper.set(entity, embeddedField, embeddedCollection);
+            }
         }
         else
         {


### PR DESCRIPTION
MongoDBDataHandler.onViaEmbeddable should check for null before using embeddedDocumentObject because in can be null in database.
