### PR TITLE
fixed npe in OneToManyRelationMetadataProcessor

### DIFF
--- a/benchmark/ycsb/src/main/java/com/impetus/kundera/ycsb/benchmark/OracleNosqlClient.java
+++ b/benchmark/ycsb/src/main/java/com/impetus/kundera/ycsb/benchmark/OracleNosqlClient.java
@@ -39,7 +39,7 @@ public class OracleNosqlClient extends DB
 
     public static final int ERROR = -1;
 
-    private static KVStoreConfig config = new KVStoreConfig("KunderaTests", "localhost:5000");
+    private static KVStoreConfig config = new KVStoreConfig("OracleNoSqlTests", "localhost:5000");
 
     private static KVStore store = KVStoreFactory.getStore(config);
 

--- a/benchmark/ycsb/src/main/java/com/impetus/kundera/ycsb/entities/OracleNosqlUser.java
+++ b/benchmark/ycsb/src/main/java/com/impetus/kundera/ycsb/entities/OracleNosqlUser.java
@@ -25,7 +25,7 @@ import javax.persistence.Table;
  * 
  */
 @Entity
-@Table(name = "kunderauser", schema = "KunderaTests@kundera_oracle_pu")
+@Table(name = "kunderauser", schema = "OracleNoSqlTests@kundera_oracle_pu")
 public class OracleNosqlUser {
 
 	@Id

--- a/benchmark/ycsb/src/main/resources/META-INF/persistence.xml
+++ b/benchmark/ycsb/src/main/resources/META-INF/persistence.xml
@@ -131,7 +131,7 @@
 			<property name="kundera.port" value="5000" />
 			<property name="kundera.client.lookup.class"
 				value="com.impetus.client.oraclenosql.OracleNoSQLClientFactory" />
-			<property name="kundera.keyspace" value="KunderaTests" />
+			<property name="kundera.keyspace" value="OracleNoSqlTests" />
 			<property name="kundera.dialect" value="kvstore" />
 			<property name="kundera.client" value="kvstore" />
 			<property name="kundera.cache.provider.class"

--- a/benchmark/ycsb/src/test/java/com/impetus/kundera/ycsb/RedisYCSBTest.java
+++ b/benchmark/ycsb/src/test/java/com/impetus/kundera/ycsb/RedisYCSBTest.java
@@ -47,7 +47,6 @@ public class RedisYCSBTest extends YCSBBaseTest
     public void onTest() throws Exception
     {
         testConcurrentWorkload();
-        
         testRead();
 //        testUpdate();
     }
@@ -62,7 +61,11 @@ public class RedisYCSBTest extends YCSBBaseTest
 
     private void testRead() throws Exception
     {
+        //stop and start server
+        onDestroy();
         onChangeRunType("t");
+        Runtime runtime = Runtime.getRuntime();
+        runner.startServer(true, runtime);
         onRead();
     }
 

--- a/src/kundera-core/src/main/java/com/impetus/kundera/metadata/processor/relation/OneToManyRelationMetadataProcessor.java
+++ b/src/kundera-core/src/main/java/com/impetus/kundera/metadata/processor/relation/OneToManyRelationMetadataProcessor.java
@@ -88,14 +88,16 @@ public class OneToManyRelationMetadataProcessor extends AbstractEntityFieldProce
             relation.setJoinTableMetadata(jtMetadata);
 */        }
         else
-        {
-            
-            String joinColumnName = ((AbstractAttribute) metadata.getIdAttribute()).getJPAColumnName();
+        {   
+            String joinColumnName = null;
+            if (metadata.getIdAttribute() != null)
+            {
+                joinColumnName = ((AbstractAttribute) metadata.getIdAttribute()).getJPAColumnName();
+            }
             if (relation.getMappedBy() != null)
             {
                 try
                 {
-
                     Field mappedField = metadata.getEntityClazz().getDeclaredField(relation.getMappedBy());
                     if (mappedField != null && mappedField.isAnnotationPresent(JoinColumn.class))
                     {

--- a/src/kundera-mongo/src/main/java/com/impetus/client/mongodb/DocumentObjectMapper.java
+++ b/src/kundera-mongo/src/main/java/com/impetus/client/mongodb/DocumentObjectMapper.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -269,8 +270,17 @@ public class DocumentObjectMapper
                 {
                 case MAP:
                     Map mapObj = (Map) valueObject;
-                    BasicDBObjectBuilder builder = BasicDBObjectBuilder.start(mapObj);
-                    dbObj.put(((AbstractAttribute) column).getJPAColumnName(), builder.get());
+                    // BasicDBObjectBuilder builder =
+                    // BasicDBObjectBuilder.start(mapObj);
+                    BasicDBObjectBuilder b = new BasicDBObjectBuilder();
+                    Iterator i = mapObj.entrySet().iterator();
+                    while (i.hasNext())
+                    {
+                        Map.Entry entry = (Map.Entry) i.next();
+                        b.add(entry.getKey().toString(),
+                                MongoDBUtils.populateValue(entry.getValue(), entry.getValue().getClass()));
+                    }
+                    dbObj.put(((AbstractAttribute) column).getJPAColumnName(), b.get());
                     break;
                 case SET:
                 case LIST:

--- a/src/kundera-mongo/src/test/java/com/impetus/client/crud/BaseTest.java
+++ b/src/kundera-mongo/src/test/java/com/impetus/client/crud/BaseTest.java
@@ -15,7 +15,9 @@
  ******************************************************************************/
 package com.impetus.client.crud;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.persistence.EntityManager;
 import javax.persistence.Query;
@@ -48,6 +50,10 @@ public abstract class BaseTest
         o.setAge(age);
         o.setDay(Day.FRIDAY);
         o.setMonth(Month.JAN);
+        Map<String, Month> map = new HashMap<String, Month>();
+        map.put("first month", Month.JAN);
+        map.put("second month", Month.FEB);
+        o.setMap(map);
         return o;
     }
 

--- a/src/kundera-mongo/src/test/java/com/impetus/client/crud/PersonMongo.java
+++ b/src/kundera-mongo/src/test/java/com/impetus/client/crud/PersonMongo.java
@@ -15,7 +15,10 @@
  ******************************************************************************/
 package com.impetus.client.crud;
 
+import java.util.Map;
+
 import javax.persistence.Column;
+import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -55,6 +58,10 @@ public class PersonMongo
     @Column(name = "MONTH_ENUM")
     @Enumerated(EnumType.STRING)
     private Month month;
+
+    @ElementCollection
+    @Column(name = "map")
+    private Map<String, Month> map;
 
     /**
      * Gets the person id.
@@ -138,5 +145,15 @@ public class PersonMongo
     enum Month
     {
         JAN, FEB, MARCH, APRIL, MAY, JUNE;
+    }
+
+    public Map<String, Month> getMap()
+    {
+        return map;
+    }
+
+    public void setMap(Map<String, Month> map)
+    {
+        this.map = map;
     }
 }

--- a/src/kundera-mongo/src/test/java/com/impetus/client/crud/PersonMongoTest.java
+++ b/src/kundera-mongo/src/test/java/com/impetus/client/crud/PersonMongoTest.java
@@ -95,6 +95,10 @@ public class PersonMongoTest extends BaseTest
         Assert.assertEquals(Day.FRIDAY, p.getDay());
         Assert.assertEquals(Month.JAN, p.getMonth());
         Assert.assertEquals("vivek", p.getPersonName());
+        Assert.assertNotNull(p.getMap());
+        Assert.assertFalse(p.getMap().isEmpty());
+        Assert.assertEquals(2, p.getMap().size());
+
         assertFindByName(em, "PersonMongo", PersonMongo.class, "vivek", "personName");
         assertFindByNameAndAge(em, "PersonMongo", PersonMongo.class, "vivek", "10", "personName");
         assertFindByNameAndAgeGTAndLT(em, "PersonMongo", PersonMongo.class, "vivek", "10", "20", "personName");
@@ -119,8 +123,7 @@ public class PersonMongoTest extends BaseTest
         allPersons = findQuery.getResultList();
         Assert.assertNotNull(allPersons);
         Assert.assertEquals(3, allPersons.size());
-        
-        
+
         query = em.createQuery("select p from PersonMongo p");
         query.setMaxResults(2);
         results = query.getResultList();
@@ -155,7 +158,7 @@ public class PersonMongoTest extends BaseTest
         Assert.assertNotNull(results.get(0).getPersonId());
         Assert.assertNull(results.get(0).getPersonName());
         Assert.assertNull(results.get(0).getAge());
-        
+
         query = "Select p.personId from PersonMongo p where p.personName = vivek";
         // // find by name.
         q = em.createQuery(query);


### PR DESCRIPTION
When trying to use inheritance and one-to-many collections I keep getting null pointers.  This commit seems to do the trick.  Stack trace below: 

java.lang.NullPointerException
    at com.impetus.kundera.metadata.processor.relation.OneToManyRelationMetadataProcessor.addRelationIntoMetadata(OneToManyRelationMetadataProcessor.java:93)
    at com.impetus.kundera.metadata.processor.TableProcessor.addRelationIntoMetadata(TableProcessor.java:181)
    at com.impetus.kundera.metadata.processor.TableProcessor.populateMetadata(TableProcessor.java:147)
    at com.impetus.kundera.metadata.processor.TableProcessor.process(TableProcessor.java:87)
    at com.impetus.kundera.metadata.MetadataBuilder.buildEntityMetadata(MetadataBuilder.java:131)
    at com.impetus.kundera.configure.MetamodelConfiguration.scanClassAndPutMetadata(MetamodelConfiguration.java:391)
    at com.impetus.kundera.configure.MetamodelConfiguration.loadEntityMetadata(MetamodelConfiguration.java:230)
    at com.impetus.kundera.configure.MetamodelConfiguration.configure(MetamodelConfiguration.java:102)
    at com.impetus.kundera.configure.Configurator.configure(Configurator.java:65)
    at com.impetus.kundera.KunderaPersistence.initializeKundera(KunderaPersistence.java:109)
    at com.impetus.kundera.KunderaPersistence.createEntityManagerFactory(KunderaPersistence.java:81)
    at javax.persistence.Persistence.createEntityManagerFactory(Persistence.java:79)
