### PR TITLE
Issue #502: Kundera JPA query for oracle DB - table name prefixed with U...

### DIFF
--- a/src/kundera-rdbms/src/main/java/com/impetus/client/rdbms/HibernateClient.java
+++ b/src/kundera-rdbms/src/main/java/com/impetus/client/rdbms/HibernateClient.java
@@ -482,8 +482,8 @@ public class HibernateClient extends ClientBase implements Client<RDBMSQuery>
     {
         EntityMetadata m = KunderaMetadataManager.getEntityMetadata(entityClazz);
         String tableName = m.getTableName();
-     // Removing the UNDERSCORE prefix as Oracle 11g complains about invalid characters error while executing the request.
-        String aliasName = tableName;
+     // Suffixing the UNDERSCORE instead of prefix as Oracle 11g complains about invalid characters error while executing the request.
+        String aliasName = tableName + "_";
         StringBuilder queryBuilder = new StringBuilder("Select ");
         // queryBuilder.append(aliasName);
         queryBuilder.append("* ");

--- a/src/kundera-rdbms/src/main/java/com/impetus/client/rdbms/HibernateClient.java
+++ b/src/kundera-rdbms/src/main/java/com/impetus/client/rdbms/HibernateClient.java
@@ -482,7 +482,8 @@ public class HibernateClient extends ClientBase implements Client<RDBMSQuery>
     {
         EntityMetadata m = KunderaMetadataManager.getEntityMetadata(entityClazz);
         String tableName = m.getTableName();
-        String aliasName = "_" + tableName;
+     // Removing the UNDERSCORE prefix as Oracle 11g complains about invalid characters error while executing the request.
+        String aliasName = tableName;
         StringBuilder queryBuilder = new StringBuilder("Select ");
         // queryBuilder.append(aliasName);
         queryBuilder.append("* ");

--- a/src/kundera-rdbms/src/main/java/com/impetus/client/rdbms/query/RDBMSEntityReader.java
+++ b/src/kundera-rdbms/src/main/java/com/impetus/client/rdbms/query/RDBMSEntityReader.java
@@ -252,8 +252,8 @@ public class RDBMSEntityReader extends AbstractEntityReader implements EntityRea
             return query != null ? query : jpaQuery;
         }
 
-        // Removing the UNDERSCORE prefix as Oracle 11g complains about invalid characters error while executing the request.
-        String aliasName = entityMetadata.getTableName();
+        // Suffixing the UNDERSCORE instead of prefix as Oracle 11g complains about invalid characters error while executing the request.
+        String aliasName = entityMetadata.getTableName() + "_";
 
         StringBuilder queryBuilder = new StringBuilder("Select ");
 

--- a/src/kundera-rdbms/src/main/java/com/impetus/client/rdbms/query/RDBMSEntityReader.java
+++ b/src/kundera-rdbms/src/main/java/com/impetus/client/rdbms/query/RDBMSEntityReader.java
@@ -252,7 +252,8 @@ public class RDBMSEntityReader extends AbstractEntityReader implements EntityRea
             return query != null ? query : jpaQuery;
         }
 
-        String aliasName = "_" + entityMetadata.getTableName();
+        // Removing the UNDERSCORE prefix as Oracle 11g complains about invalid characters error while executing the request.
+        String aliasName = entityMetadata.getTableName();
 
         StringBuilder queryBuilder = new StringBuilder("Select ");
 


### PR DESCRIPTION
...NDERSCORE

This is a fix for
https://github.com/impetus-opensource/Kundera/issues/502.
Removing the UNDERSCORE prefix while generating the select queries. 

This is tested for both MySql and Oracle 11g servers.
