### PR TITLE
Handle Sub-queries with mongodb additional features

### DIFF
--- a/src/jpa-engine/core/src/main/java/com/impetus/kundera/query/KunderaQuery.java
+++ b/src/jpa-engine/core/src/main/java/com/impetus/kundera/query/KunderaQuery.java
@@ -59,17 +59,17 @@ public class KunderaQuery
             "WHERE", "GROUP BY", "HAVING", "ORDER BY" };
 
     /** The Constant INTER_CLAUSE_OPERATORS. */
-    public static final String[] INTER_CLAUSE_OPERATORS = { "AND", "OR", "BETWEEN" };
+    public static final String[] INTER_CLAUSE_OPERATORS = { "AND", "OR", "BETWEEN", "(", ")" };
 
     /** The Constant INTRA_CLAUSE_OPERATORS. */
-    public static final String[] INTRA_CLAUSE_OPERATORS = { "=", "LIKE", "IN", ">", ">=", "<", "<=" };
+    public static final String[] INTRA_CLAUSE_OPERATORS = { "=", "LIKE", "IN", ">", ">=", "<", "<=", "<>", "NOT IN" };
 
     /** The INTER pattern. */
     private static final Pattern INTER_CLAUSE_PATTERN = Pattern.compile(
-            "\\s\\band\\b\\s|\\s\\bor\\b\\s|\\s\\bbetween\\b\\s", Pattern.CASE_INSENSITIVE);
+            "\\s\\band\\b\\s|\\s\\bor\\b\\s|\\s\\bbetween\\b\\s|\\(|\\)", Pattern.CASE_INSENSITIVE);
 
     /** The INTRA pattern. */
-    private static final Pattern INTRA_CLAUSE_PATTERN = Pattern.compile("=|\\s\\blike\\b|\\bin\\b|>=|>|<=|<|\\s\\bset",
+    private static final Pattern INTRA_CLAUSE_PATTERN = Pattern.compile("=|\\s\\blike\\b|\\bin\\b|\\bnot in\\b|>=|>|<=|<|<>|\\s\\bset",
             Pattern.CASE_INSENSITIVE);
 
     /** The logger. */
@@ -270,10 +270,10 @@ public class KunderaQuery
     {
         if (typedParameter != null && typedParameter.getParameters() != null)
         {
-            FilterClause clause = typedParameter.getParameters().get(paramString);
-            if (clause != null)
+            List<FilterClause> clauses = typedParameter.getParameters().get(paramString);
+            if (clauses != null)
             {
-                return clause.getValue();
+                return clauses.get(0).getValue();
             }
             else
             {
@@ -305,18 +305,18 @@ public class KunderaQuery
                     match = p;
                     if (typedParameter.getType().equals(Type.NAMED))
                     {
-                        FilterClause clause = typedParameter.getParameters().get(":" + p.getName());
-                        if (clause != null)
+                        List<FilterClause> clauses = typedParameter.getParameters().get(":" + p.getName());
+                        if (clauses != null)
                         {
-                            return clause.getValue();
+                            return clauses.get(0).getValue();
                         }
                     }
                     else
                     {
-                        FilterClause clause = typedParameter.getParameters().get("?" + p.getPosition());
-                        if (clause != null)
+                    	List<FilterClause> clauses = typedParameter.getParameters().get("?" + p.getPosition());
+                        if (clauses != null)
                         {
-                            return clause.getValue();
+                            return clauses.get(0).getValue();
                         }
                         else
                         {
@@ -460,7 +460,12 @@ public class KunderaQuery
 
         for (String clause : clauses)
         {
-            if (newClause)
+        	if(clause.trim().equals("(") || clause.trim().equals(")"))
+        	{
+                filtersQueue.add(clause.trim());
+                newClause = true;
+            }
+        	else if (newClause)
             {
                 List<String> tokens = tokenize(clause, INTRA_CLAUSE_PATTERN);
 
@@ -520,7 +525,7 @@ public class KunderaQuery
             {
                 if (Arrays.asList(INTER_CLAUSE_OPERATORS).contains(clause.toUpperCase().trim()))
                 {
-                    filtersQueue.add(clause.toUpperCase());
+                    filtersQueue.add(clause.toUpperCase().trim());
                     newClause = true;
                 }
                 else
@@ -715,11 +720,13 @@ public class KunderaQuery
     {
         if (typedParameter != null)
         {
-            FilterClause clause = typedParameter.getParameters() != null ? typedParameter.getParameters().get(name)
+            List<FilterClause> clauses = typedParameter.getParameters() != null ? typedParameter.getParameters().get(name)
                     : null;
-            if (clause != null)
+            if (clauses != null)
             {
-                clause.setValue(value);
+            	for (FilterClause clause : clauses) {
+            		clause.setValue(value);
+				}
             }
             else
             {
@@ -990,14 +997,16 @@ public class KunderaQuery
         while (matcher.find())
         {
             s = where.substring(lastIndex, matcher.start()).trim();
-            split.add(s);
+            if(!s.equals(""))
+            	split.add(s);
             s = matcher.group();
             split.add(s.toUpperCase());
             lastIndex = matcher.end();
             // count++;
         }
         s = where.substring(lastIndex).trim();
-        split.add(s);
+        if(!s.equals(""))
+        	split.add(s);
         return split;
     }
 
@@ -1205,7 +1214,7 @@ public class KunderaQuery
 
         private Set<Parameter<?>> jpaParameters = new HashSet<Parameter<?>>();
 
-        private Map<String, FilterClause> parameters;
+        private Map<String, List<FilterClause>> parameters;
 
         private Map<String, UpdateClause> updateParameters;
 
@@ -1228,7 +1237,7 @@ public class KunderaQuery
         /**
          * @return the parameters
          */
-        Map<String, FilterClause> getParameters()
+        Map<String, List<FilterClause>> getParameters()
         {
             return parameters;
         }
@@ -1245,10 +1254,12 @@ public class KunderaQuery
         {
             if (parameters == null)
             {
-                parameters = new HashMap<String, FilterClause>();
+                parameters = new HashMap<String, List<FilterClause>>();
             }
-
-            parameters.put(key, clause);
+            if(!parameters.containsKey(key)) {
+            	parameters.put(key, new ArrayList<KunderaQuery.FilterClause>());
+            }
+            parameters.get(key).add(clause);
         }
 
         void addParameters(String key, UpdateClause clause)

--- a/src/jpa-engine/core/src/main/java/com/impetus/kundera/query/KunderaQuery.java
+++ b/src/jpa-engine/core/src/main/java/com/impetus/kundera/query/KunderaQuery.java
@@ -69,7 +69,7 @@ public class KunderaQuery
             "\\s\\band\\b\\s|\\s\\bor\\b\\s|\\s\\bbetween\\b\\s|\\(|\\)", Pattern.CASE_INSENSITIVE);
 
     /** The INTRA pattern. */
-    private static final Pattern INTRA_CLAUSE_PATTERN = Pattern.compile("=|\\s\\blike\\b|\\bin\\b|\\bnot in\\b|>=|>|<=|<|<>|\\s\\bset",
+    private static final Pattern INTRA_CLAUSE_PATTERN = Pattern.compile("=|\\s\\blike\\b|\\bnot in\\b|\\bin\\b|<>|>=|>|<=|<|\\s\\bset",
             Pattern.CASE_INSENSITIVE);
 
     /** The logger. */
@@ -460,9 +460,9 @@ public class KunderaQuery
 
         for (String clause : clauses)
         {
-        	if(clause.trim().equals("(") || clause.trim().equals(")"))
+        	if(Arrays.asList(INTER_CLAUSE_OPERATORS).contains(clause.toUpperCase().trim()))
         	{
-                filtersQueue.add(clause.trim());
+                filtersQueue.add(clause.toUpperCase().trim());
                 newClause = true;
             }
         	else if (newClause)
@@ -523,15 +523,7 @@ public class KunderaQuery
             }
             else
             {
-                if (Arrays.asList(INTER_CLAUSE_OPERATORS).contains(clause.toUpperCase().trim()))
-                {
-                    filtersQueue.add(clause.toUpperCase().trim());
-                    newClause = true;
-                }
-                else
-                {
-                    throw new JPQLParseException("bad jpa query: " + clause);
-                }
+                throw new JPQLParseException("bad jpa query: " + clause);
             }
         }
 

--- a/src/jpa-engine/core/src/main/java/com/impetus/kundera/query/QueryImpl.java
+++ b/src/jpa-engine/core/src/main/java/com/impetus/kundera/query/QueryImpl.java
@@ -86,6 +86,8 @@ public abstract class QueryImpl<E> implements Query, com.impetus.kundera.query.Q
      * Default maximum result to fetch.
      */
     protected int maxResult = 100;
+    
+    protected int firstResult = 0;
 
     private Integer fetchSize;
 
@@ -373,7 +375,8 @@ public abstract class QueryImpl<E> implements Query, com.impetus.kundera.query.Q
     @Override
     public Query setFirstResult(int startPosition)
     {
-        throw new UnsupportedOperationException("setFirstResult is unsupported by Kundera");
+    	this.firstResult = startPosition;
+    	return this;
     }
 
     /*

--- a/src/jpa-engine/core/src/test/java/com/impetus/kundera/query/KunderaQueryTest.java
+++ b/src/jpa-engine/core/src/test/java/com/impetus/kundera/query/KunderaQueryTest.java
@@ -438,6 +438,52 @@ public class KunderaQueryTest
         }
 
     }
+    
+    @Test
+    public void testInNotInNotEquals()
+    {
+        String query = "Select p from Person p where p.personName <> :name and p.age IN :ageList" +
+        		" and salary NOT IN :salaryList and (personId = :personId)";
+        KunderaQuery kunderaQuery = new KunderaQuery(query, kunderaMetadata);
+        KunderaQueryParser queryParser = new KunderaQueryParser(kunderaQuery);
+        queryParser.parse();
+        kunderaQuery.postParsingInit();
+        kunderaQuery.setParameter("name", "pname");
+        kunderaQuery.setParameter("ageList", new ArrayList<Integer>(){{add(20);add(21);}});
+        kunderaQuery.setParameter("salaryList", new ArrayList<Double>(){{add(2000D);add(3000D);}});
+        kunderaQuery.setParameter("personId", "personId");
+
+        Assert.assertEquals(4, kunderaQuery.getParameters().size());
+
+        Iterator<Parameter<?>> parameters = kunderaQuery.getParameters().iterator();
+
+        while (parameters.hasNext())
+        {
+            Assert.assertTrue(kunderaQuery.isBound(parameters.next()));
+        }
+        
+        List<String> nameList = new ArrayList<String>();
+        nameList.add("pname");
+        List<Integer> ageList = new ArrayList<Integer>(){{add(20);add(21);}};
+        List<Double> salaryList = new ArrayList<Double>(){{add(2000D);add(3000D);}};
+        List<String> personIdList = new ArrayList<String>();
+        personIdList.add("personId");
+
+        Object value = kunderaQuery.getClauseValue(":name");
+        Assert.assertNotNull(value);
+        Assert.assertEquals(nameList, value);
+        value = kunderaQuery.getClauseValue(":ageList");
+        Assert.assertNotNull(value);
+        Assert.assertEquals(ageList, value);
+        value = kunderaQuery.getClauseValue(":salaryList");
+        Assert.assertNotNull(value);
+        Assert.assertEquals(salaryList, value);
+        value = kunderaQuery.getClauseValue(":personId");
+        Assert.assertNotNull(value);
+        Assert.assertEquals(personIdList, value);
+        Assert.assertEquals(4, kunderaQuery.getParameters().size());
+
+    }
 
     private class JPAParameter implements Parameter<String>
     {

--- a/src/kundera-mongo/src/main/java/com/impetus/client/mongodb/MongoDBDataHandler.java
+++ b/src/kundera-mongo/src/main/java/com/impetus/client/mongodb/MongoDBDataHandler.java
@@ -298,7 +298,7 @@ public final class MongoDBDataHandler
      * @throws InstantiationException
      */
     List getEmbeddedObjectList(DBCollection dbCollection, EntityMetadata m, String documentName,
-            BasicDBObject mongoQuery, String result, BasicDBObject orderBy, int maxResult, BasicDBObject keys, final KunderaMetadata kunderaMetadata)
+            BasicDBObject mongoQuery, String result, BasicDBObject orderBy, int maxResult, int firstResult, BasicDBObject keys, final KunderaMetadata kunderaMetadata)
             throws PropertyAccessException, InstantiationException, IllegalAccessException
     {
         List list = new ArrayList();// List of embedded object to be returned
@@ -347,7 +347,7 @@ public final class MongoDBDataHandler
 
         // Query for fetching entities based on user specified criteria
         DBCursor cursor = orderBy != null ? dbCollection.find(mongoQuery, keys).sort(orderBy) : dbCollection.find(
-                mongoQuery, keys).limit(maxResult);
+                mongoQuery, keys).limit(maxResult).skip(firstResult);;
 
         if (superColumn != null)
         {

--- a/src/kundera-mongo/src/main/java/com/impetus/client/mongodb/query/ResultIterator.java
+++ b/src/kundera-mongo/src/main/java/com/impetus/client/mongodb/query/ResultIterator.java
@@ -63,7 +63,7 @@ class ResultIterator<E> implements IResultIterator<E>
         this.fetchSize = fetchSize;
         this.persistenceDelegator = pd;
         this.handler = new MongoDBDataHandler();
-        this.cursor = client.getDBCursorInstance(basicDBObject, orderByClause, fetchSize, keys, m.getTableName());
+        this.cursor = (DBCursor)client.getDBCursorInstance(basicDBObject, orderByClause, fetchSize, 0, keys, m.getTableName(), false);
     }
 
     @Override

--- a/src/kundera-mongo/src/test/java/com/impetus/client/crud/PersonMongoTest.java
+++ b/src/kundera-mongo/src/test/java/com/impetus/client/crud/PersonMongoTest.java
@@ -15,6 +15,7 @@
  ******************************************************************************/
 package com.impetus.client.crud;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -341,6 +342,58 @@ public class PersonMongoTest extends BaseTest
                     "java.lang.UnsupportedOperationException: Native query support is not enabled in mongoDB",
                     e.getMessage());
         }
+
+    }
+    
+    @Test
+    public void incrementFunctionTest()
+    {
+    	Object p1 = prepareMongoInstance("1", 10);
+        em.persist(p1);
+        
+        String updateFunc = "UPDATE PersonMongo set age = INCREMENT(1) where personId = :personId";
+        Query q = em.createQuery(updateFunc);
+        q.setParameter("personId", "1");
+        Assert.assertEquals(1, q.executeUpdate());
+        
+        updateFunc = "UPDATE PersonMongo set age = DECREMENT(1) where personId = :personId";
+        q = em.createQuery(updateFunc);
+        q.setParameter("personId", "1");
+        Assert.assertEquals(1, q.executeUpdate());
+    }
+    
+    @Test
+    public void subQueryTest()
+    {
+    	Object p1 = prepareMongoInstance("1", 10);
+        Object p2 = prepareMongoInstance("2", 20);
+        Object p3 = prepareMongoInstance("3", 15);
+        em.persist(p1);
+        em.persist(p2);
+        em.persist(p3);
+    	
+    	String query = "Select p from PersonMongo p where p.personName <> :name and p.age NOT IN :ageList" +
+        		" and (personId = :personId)";
+        Query q = em.createQuery(query);
+        q.setParameter("name", "vivek");
+        q.setParameter("ageList", new ArrayList<Integer>(){{add(20);add(21);}});
+        q.setParameter("personId", "1");
+        List<PersonMongo> results = q.getResultList();
+        Assert.assertNotNull(results);
+        Assert.assertEquals(0, results.size());
+        
+        query = "Select p from PersonMongo p where (p.personName = :name and p.age NOT IN :ageList)" +
+        		" and (personId = :personId)";
+        q = em.createQuery(query);
+        q.setParameter("name", "vivek");
+        q.setParameter("ageList", new ArrayList<Integer>(){{add(20);add(21);}});
+        q.setParameter("personId", "1");
+        results = q.getResultList();
+        Assert.assertNotNull(results);
+        Assert.assertEquals(1, results.size());
+        Assert.assertNotNull(results.get(0).getPersonId());
+        Assert.assertNotNull(results.get(0).getPersonName());
+        Assert.assertNotNull(results.get(0).getAge());
 
     }
 }


### PR DESCRIPTION
# Core

KunderaQuery:
1. Added support for 'NOT IN' and '<>'
2. Added support for sub-queries - keywords '(' and ')'
3. The same column/parameter value pair may be repeated multiple times in a query, fixed this with the List<FilterClause> instead of single FilterClause
4. Fixed the tokenize function to ignore blank values
5. While adding INTER_CLAUSE_OPERATORS to the FilterClause queue make sure we trim the operators

QueryImpl:
1. Added support for setFirstResult (pagination)
# Mongodb Client

MongoDBClient:
1. Added support for pagination (skip) function in mongodb
2. Added support for count query

MongoDBDataHandler:
1. Added support for pagination (skip) function in mongodb

MongoDBQuery:
1. Added support for pagination (skip) function in mongodb
2. Added new QueryComponent class to handle subqueries based on AND/OR/(/)
3. Added support for 'IN', 'NOT IN' and '<>' for mongodb-client
4. Added support for '$inc' in the form of special UPDATE functions in mongodb-client

ResultIterator:
1. Resolved compilation error
