### PR TITLE
fixed hashcode generation on Node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.iws
 *.iml
 *.ipr
+.idea
 target/
 test-output/
 

--- a/src/jpa-engine/core/src/main/java/com/impetus/kundera/graph/Node.java
+++ b/src/jpa-engine/core/src/main/java/com/impetus/kundera/graph/Node.java
@@ -428,7 +428,7 @@ public class Node implements NodeStateContext
     @Override
     public int hashCode()
     {
-        return HashCodeBuilder.reflectionHashCode(this.nodeId);
+        return HashCodeBuilder.reflectionHashCode(this);
     }
 
     // ////////////////////////////////////////


### PR DESCRIPTION
Hi, I had some problems deploying Kundera on Google App Engine, I've [discussed](https://groups.google.com/forum/#!topic/kundera-discuss/qS_LqARuTTU) the details on Kundera google group.

I think the problem was that the hashCode for _Node_ was being generated reflecting over _nodeId_ which is a _String_.

With that fix now everything work fine on app engine runtime.
If that was somehow intentional fell free to ignore the pull request.
