### PR TITLE
Not applying pool configs

### DIFF
--- a/src/kundera-cassandra/cassandra-core/src/main/java/com/impetus/client/cassandra/thrift/ThriftClientFactory.java
+++ b/src/kundera-cassandra/cassandra-core/src/main/java/com/impetus/client/cassandra/thrift/ThriftClientFactory.java
@@ -172,7 +172,7 @@ public class ThriftClientFactory extends CassandraClientFactory
             prop.setPort(host.getPort());
             prop.setKeySpace(keyspace);
 
-            CassandraUtilities.setPoolConfigPolicy((CassandraHost) host, prop);
+            prop = CassandraUtilities.setPoolConfigPolicy((CassandraHost) host, prop);
             try
             {
                 ConnectionPool pool = new ConnectionPool(prop);


### PR DESCRIPTION
kundera was not working properly was missing configs.

Using the Thrift driver.

lets say we have this on persistence.xml:

```
        <property name="kundera.pool.size.max.total"  value="5000"/>
            <property name="kundera.pool.size.max.active" value="5000"/>
        <property name="kundera.pool.size.max.idle"   value="5000"/>
        <property name="kundera.pool.size.min.idle"   value="5000"/>
```

Check the classes:
       ThriftClientFactory.createPoolOrConnection line 175:
              CassandraUtilities.setPoolConfigPolicy((CassandraHost) host, prop)

```
   this is not working, making use always the default pool 100 no matter what value do you set it always use the dfault values setted on: net.dataforte.cassandra.pool.PoolProperties
```

Here is a sample fix:
   prop = CassandraUtilities.setPoolConfigPolicy((CassandraHost) host, prop);

Cheers,
Diego Pacheco
