### PR TITLE
mapping nullable column value to entity value for datastax cassandra …

### DIFF
--- a/src/kundera-cassandra/cassandra-ds-driver/src/main/java/com/impetus/kundera/client/cassandra/dsdriver/DSClientUtilities.java
+++ b/src/kundera-cassandra/cassandra-ds-driver/src/main/java/com/impetus/kundera/client/cassandra/dsdriver/DSClientUtilities.java
@@ -125,7 +125,11 @@ public final class DSClientUtilities
          * }
          */
         Object retVal = null;
-
+        
+        if(row.isNull(columnName)){
+        	return entity;
+        }
+        
         switch (dataType)
         {
         case BLOB:
@@ -447,6 +451,9 @@ public final class DSClientUtilities
     private static void setBasicValue(Object entity, Field member, String columnName, UDTValue row,
             CassandraType dataType, MetamodelImpl metamodel)
     {
+    	if(row.isNull(columnName)){
+        	return;
+        }
         Object retVal = null;
         switch (dataType)
         {


### PR DESCRIPTION
Kundera datastax cassandra client is simply populating default value in the entity result for nullable primitive type columns  while reading from database. The full details of issue is https://github.com/impetus-opensource/Kundera/issues/785 
