### PR TITLE
Mongo patches (Count and EmbeddedId)

### DIFF
--- a/src/kundera-mongo/src/main/java/com/impetus/client/mongodb/query/MongoDBQuery.java
+++ b/src/kundera-mongo/src/main/java/com/impetus/client/mongodb/query/MongoDBQuery.java
@@ -30,6 +30,9 @@ import javax.persistence.metamodel.EntityType;
 import javax.persistence.metamodel.Metamodel;
 
 import org.apache.commons.lang.StringUtils;
+import org.eclipse.persistence.jpa.jpql.parser.CountFunction;
+import org.eclipse.persistence.jpa.jpql.parser.Expression;
+import org.eclipse.persistence.jpa.jpql.parser.SelectClause;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -156,8 +159,8 @@ public class MongoDBQuery extends QueryImpl
                 BasicDBObject orderByClause = getOrderByClause(m);
                 return ((MongoDBClient) client).loadData(m,
                         createMongoQuery(m, getKunderaQuery().getFilterClauseQueue()), null, orderByClause,
-                        isSingleResult ? 1 : maxResult, firstResult, getKeys(m, getKunderaQuery().getResult()),
-                        getKunderaQuery().getResult());
+                        isSingleResult ? 1 : maxResult, firstResult, isCountQuery(),
+                        getKeys(m, getKunderaQuery().getResult()), getKunderaQuery().getResult());
             }
             else
             {
@@ -181,7 +184,7 @@ public class MongoDBQuery extends QueryImpl
             BasicDBObject orderByClause = getOrderByClause(m);
             // find on id, so no need to add skip() [firstResult hardcoded 0]
             return ((MongoDBClient) client).loadData(m, createMongoQuery(m, getKunderaQuery().getFilterClauseQueue()),
-                    null, orderByClause, isSingleResult ? 1 : maxResult, 0,
+                    null, orderByClause, isSingleResult ? 1 : maxResult, 0, isCountQuery(),
                     getKeys(m, getKunderaQuery().getResult()), getKunderaQuery().getResult());
         }
         catch (Exception e)
@@ -215,7 +218,7 @@ public class MongoDBQuery extends QueryImpl
                 BasicDBObject orderByClause = getOrderByClause(m);
                 ls = ((MongoDBClient) client).loadData(m,
                         createMongoQuery(m, getKunderaQuery().getFilterClauseQueue()), m.getRelationNames(),
-                        orderByClause, isSingleResult ? 1 : maxResult, firstResult,
+                        orderByClause, isSingleResult ? 1 : maxResult, firstResult, isCountQuery(),
                         getKeys(m, getKunderaQuery().getResult()), getKunderaQuery().getResult());
             }
             else
@@ -230,6 +233,21 @@ public class MongoDBQuery extends QueryImpl
         }
 
         return setRelationEntities(ls, client, m);
+    }
+
+    private boolean isCountQuery()
+    {
+        if (getKunderaQuery().getSelectStatement() != null) {
+            final Expression selectClause = getKunderaQuery().getSelectStatement().getSelectClause();
+
+            if (selectClause instanceof SelectClause) {
+                final Expression expression = ((SelectClause) selectClause).getSelectExpression();
+
+                return expression instanceof CountFunction;
+            }
+        }
+
+        return false;
     }
 
     /*

--- a/src/kundera-mongo/src/main/java/com/impetus/client/mongodb/query/MongoDBQuery.java
+++ b/src/kundera-mongo/src/main/java/com/impetus/client/mongodb/query/MongoDBQuery.java
@@ -479,7 +479,10 @@ public class MongoDBQuery extends QueryImpl
 
                     if (isCompositeColumn)
                     {
-                        property = new StringBuffer("_id.").append(property).toString();
+                        EmbeddableType embeddableType = metaModel.embeddable(m.getIdAttribute().getBindableJavaType());
+                        AbstractAttribute attribute = (AbstractAttribute) embeddableType.getAttribute(property);
+
+                        property = new StringBuffer("_id.").append(attribute.getJPAColumnName()).toString();
                     }
                     if (condition.equals("="))
                     {

--- a/src/kundera-mongo/src/test/java/com/impetus/client/crud/EmbeddableIdTest.java
+++ b/src/kundera-mongo/src/test/java/com/impetus/client/crud/EmbeddableIdTest.java
@@ -1,0 +1,103 @@
+package com.impetus.client.crud;
+
+import com.impetus.client.crud.entities.CompositeId;
+import com.impetus.client.crud.entities.CompositeUser;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Persistence;
+import javax.persistence.Query;
+import java.util.List;
+
+/**
+ * This test verifies embedded IDs work in queries
+ * when the field name is different from the column name.
+ */
+public class EmbeddableIdTest {
+
+   private EntityManagerFactory emf;
+
+   /** The em. */
+   private EntityManager em;
+
+   @Before
+   public void setUp()
+   {
+      emf = Persistence.createEntityManagerFactory("mongoTest");
+      em = emf.createEntityManager();
+
+      prepareData();
+   }
+
+   @Test
+   public void testSelect()
+   {
+      Query query = null;
+      List<?> results = null;
+
+      query = em.createQuery("select u from CompositeUser u");
+      results = query.getResultList();
+
+      Assert.assertNotNull(results);
+      Assert.assertEquals(results.size(), 3);
+
+      query = em.createQuery("select u from CompositeUser u where u.id.birthDate = :year");
+      query.setParameter("year", "1986");
+      results = query.getResultList();
+
+      Assert.assertNotNull(results);
+      Assert.assertEquals(results.size(), 1);
+
+      query = em.createQuery("select u from CompositeUser u where u.id.birthDate <= :year");
+      query.setParameter("year", "1986");
+      results = query.getResultList();
+
+      Assert.assertNotNull(results);
+      Assert.assertEquals(results.size(), 2);
+   }
+
+   private void prepareData()
+   {
+      CompositeId id1 = new CompositeId();
+      id1.setFirstName("John");
+      id1.setBirthDate("1981");
+
+      CompositeUser user1 = new CompositeUser();
+      user1.setId(id1);
+      user1.setPhone("90001");
+
+      em.persist(user1);
+
+      CompositeId id2 = new CompositeId();
+      id2.setFirstName("Carl");
+      id2.setBirthDate("1988");
+
+      CompositeUser user2 = new CompositeUser();
+      user2.setId(id2);
+      user2.setPhone("90002");
+
+      em.persist(user2);
+
+      CompositeId id3 = new CompositeId();
+      id3.setFirstName("Viktor");
+      id3.setBirthDate("1986");
+
+      CompositeUser user3 = new CompositeUser();
+      user3.setId(id3);
+      user3.setPhone("90003");
+
+      em.persist(user3);
+   }
+
+   @After
+   public void tearDown()
+   {
+      em.close();
+      emf.close();
+   }
+
+}

--- a/src/kundera-mongo/src/test/java/com/impetus/client/crud/PersonMongoTest.java
+++ b/src/kundera-mongo/src/test/java/com/impetus/client/crud/PersonMongoTest.java
@@ -890,4 +890,32 @@ public class PersonMongoTest extends BaseTest
             }
         }
     }
+
+    @Test
+    public void countTest()
+    {
+        Object p1 = prepareMongoInstance("1", 10);
+        Object p2 = prepareMongoInstance("2", 20);
+        Object p3 = prepareMongoInstance("3", 15);
+        em.persist(p1);
+        em.persist(p2);
+        em.persist(p3);
+
+        Query query = em.createQuery("select count(p) from PersonMongo p");
+        List<?> results = query.getResultList();
+        Assert.assertNotNull(results);
+        Assert.assertEquals(results.size(), 1);
+        Assert.assertEquals(results.get(0), 3L);
+
+        query = em.createQuery("select count(p) from PersonMongo p where p.age < 18");
+        results = query.getResultList();
+        Assert.assertNotNull(results);
+        Assert.assertEquals(results.size(), 1);
+        Assert.assertEquals(results.get(0), 2L);
+
+        query = em.createQuery("select count(p) from PersonMongo p");
+        Object singleResult = query.getSingleResult();
+        Assert.assertEquals(singleResult, 3L);
+    }
+
 }

--- a/src/kundera-mongo/src/test/java/com/impetus/client/crud/entities/CompositeId.java
+++ b/src/kundera-mongo/src/test/java/com/impetus/client/crud/entities/CompositeId.java
@@ -1,0 +1,37 @@
+package com.impetus.client.crud.entities;
+
+import javax.persistence.Basic;
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+
+@Embeddable
+public class CompositeId {
+
+   @Basic
+   @Column(name = "first_name")
+   private String firstName;
+
+   @Basic
+   @Column(name = "birth_date")
+   private String birthDate;
+
+   public String getFirstName()
+   {
+      return firstName;
+   }
+
+   public void setFirstName(final String firstName)
+   {
+      this.firstName = firstName;
+   }
+
+   public String getBirthDate()
+   {
+      return birthDate;
+   }
+
+   public void setBirthDate(final String birthDate)
+   {
+      this.birthDate = birthDate;
+   }
+}

--- a/src/kundera-mongo/src/test/java/com/impetus/client/crud/entities/CompositeUser.java
+++ b/src/kundera-mongo/src/test/java/com/impetus/client/crud/entities/CompositeUser.java
@@ -1,0 +1,36 @@
+package com.impetus.client.crud.entities;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "composite_user")
+public class CompositeUser {
+
+   @EmbeddedId
+   private CompositeId id;
+
+   @Basic
+   @Column(name = "phone")
+   private String phone;
+
+   public CompositeId getId()
+   {
+      return id;
+   }
+
+   public void setId(final CompositeId id)
+   {
+      this.id = id;
+   }
+
+   public String getPhone()
+   {
+      return phone;
+   }
+
+   public void setPhone(final String phone)
+   {
+      this.phone = phone;
+   }
+
+}


### PR DESCRIPTION
Hi,

This PR contains two changes related to MongoDB:
1. Count JPA queries like `select count(e) from Entity e` should now work
2. Field names weren't translated to column names in embedded IDs.
