### PR TITLE
Allow using AS for alias of table name

### DIFF
--- a/src/jpa-engine/core/src/main/java/com/impetus/kundera/query/KunderaQuery.java
+++ b/src/jpa-engine/core/src/main/java/com/impetus/kundera/query/KunderaQuery.java
@@ -568,6 +568,11 @@ public class KunderaQuery
 
         if (!this.isDeleteUpdate)
         {
+            if (fromArray.length == 3 && fromArray[1].equalsIgnoreCase("as"))
+            {
+                fromArray = new String[] { fromArray[0], fromArray[2] };
+            }
+
             if (fromArray.length != 2)
             {
                 throw new JPQLParseException("Bad query format: " + from

--- a/src/jpa-engine/core/src/test/java/com/impetus/kundera/query/KunderaQueryTest.java
+++ b/src/jpa-engine/core/src/test/java/com/impetus/kundera/query/KunderaQueryTest.java
@@ -93,6 +93,25 @@ public class KunderaQueryTest
         Assert.assertNotNull(kunderaQuery.getResult());
         Assert.assertEquals(PU, kunderaQuery.getPersistenceUnit());
         Assert.assertNull(kunderaQuery.getOrdering());
+
+        query = "Select p from Person as p";
+        kunderaQuery = new KunderaQuery(query, kunderaMetadata);
+        queryParser = new KunderaQueryParser(kunderaQuery);
+        queryParser.parse();
+        kunderaQuery.postParsingInit();
+        Assert.assertNotNull(kunderaQuery.getEntityClass());
+        Assert.assertEquals(Person.class, kunderaQuery.getEntityClass());
+        Assert.assertNotNull(kunderaQuery.getEntityMetadata());
+        Assert.assertTrue(KunderaMetadataManager.getEntityMetadata(kunderaMetadata, Person.class).equals(
+              kunderaQuery.getEntityMetadata()));
+        Assert.assertNull(kunderaQuery.getFilter());
+        Assert.assertTrue(kunderaQuery.getFilterClauseQueue().isEmpty());
+        Assert.assertNotNull(kunderaQuery.getFrom());
+        Assert.assertTrue(kunderaQuery.getUpdateClauseQueue().isEmpty());
+        Assert.assertNotNull(kunderaQuery.getResult());
+        Assert.assertEquals(PU, kunderaQuery.getPersistenceUnit());
+        Assert.assertNull(kunderaQuery.getOrdering());
+
         try
         {
             query = "Select p from p";


### PR DESCRIPTION
This change is to allow having `AS` in `SELECT` statements, like `select e from Entity as e` which is allowed by the JPA spec: http://openjpa.apache.org/builds/1.0.4/apache-openjpa-1.0.4/docs/manual/jpa_langref.html#jpa_langref_bnf