### PR TITLE
Query building changes plus Mongo additions/fixes

### DIFF
--- a/src/jpa-engine/core/src/main/java/com/impetus/kundera/Constants.java
+++ b/src/jpa-engine/core/src/main/java/com/impetus/kundera/Constants.java
@@ -147,6 +147,9 @@ public interface Constants
     /** The Constant COL_NAME. */
     public static final String COL_NAME = "colName";
 
+    /** The Constant IGNORE_CASE. */
+    public static final String IGNORE_CASE = "ignoreCase";
+
     /** The Constant COMPOSITE. */
     public final static String COMPOSITE = "composite";
 

--- a/src/jpa-engine/core/src/main/java/com/impetus/kundera/query/KunderaQuery.java
+++ b/src/jpa-engine/core/src/main/java/com/impetus/kundera/query/KunderaQuery.java
@@ -1058,6 +1058,9 @@ public class KunderaQuery
         /** The value. */
         private List<Object> value = new ArrayList<Object>();
 
+        /** Whether to ignore case while evaluating the condition */
+        private boolean ignoreCase;
+
         /**
          * The Constructor.
          * 
@@ -1141,6 +1144,26 @@ public class KunderaQuery
             }
 
             this.value = valObjects;
+        }
+
+        /**
+         * Returns whether to ignore the case when evaluating the filter clause.
+         *
+         * @return whether to ignore the case when evaluating the filter clause
+         */
+        public boolean isIgnoreCase()
+        {
+            return ignoreCase;
+        }
+
+        /**
+         * Sets whether to ignore the case when evaluating the filter clause.
+         *
+         * @param ignoreCase true to ignore the case when evaluating the filter clause
+         */
+        public void setIgnoreCase(final boolean ignoreCase)
+        {
+            this.ignoreCase = ignoreCase;
         }
 
         /* @see java.lang.Object#toString() */
@@ -1438,13 +1461,16 @@ public class KunderaQuery
      *            the value
      * @param fieldName
      *            the field name
+     * @param ignoreCase
+     *            to ignore case in the filter
      */
     public void addFilterClause(final String property, final String condition, final Object value,
-            final String fieldName)
+            final String fieldName, final boolean ignoreCase)
     {
         if (property != null && condition != null)
         {
             FilterClause filterClause = new FilterClause(property.trim(), condition.trim(), value, fieldName);
+            filterClause.setIgnoreCase(ignoreCase);
             filtersQueue.add(filterClause);
         }
         else

--- a/src/jpa-engine/core/src/main/java/com/impetus/kundera/query/KunderaQuery.java
+++ b/src/jpa-engine/core/src/main/java/com/impetus/kundera/query/KunderaQuery.java
@@ -783,6 +783,11 @@ public class KunderaQuery
     private void onTypedParameter(FilterClause filterClause)
     {
 
+        if (filterClause.value != null && filterClause.value.get(0) == null)
+        {
+            return;
+        }
+
         if (filterClause.value != null && filterClause.value.get(0).toString().startsWith(":"))
         {
             addTypedParameter(Type.NAMED, filterClause.value.get(0).toString(), filterClause);

--- a/src/jpa-engine/core/src/main/java/com/impetus/kundera/query/KunderaQueryUtils.java
+++ b/src/jpa-engine/core/src/main/java/com/impetus/kundera/query/KunderaQueryUtils.java
@@ -417,12 +417,14 @@ public final class KunderaQueryUtils
         Map<String, Object> map = new HashMap<String, Object>();
 
         boolean isEmbeddable = false;
+        boolean isAssociation = false;
         int count = 1;
         String fieldName = pathExp.getPath(count++);
 
         AbstractAttribute attrib = (AbstractAttribute) entity.getAttribute(fieldName);
         String dbColName = attrib.getJPAColumnName();
         isEmbeddable = metaModel.isEmbeddable(attrib.getBindableJavaType());
+        isAssociation = attrib.isAssociation();
         while (pathExp.pathSize() > count)
         {
             if (isEmbeddable)
@@ -432,6 +434,17 @@ public final class KunderaQueryUtils
                 fieldName = fieldName + "." + attName;
                 attrib = (AbstractAttribute) embeddableType.getAttribute(attName);
                 isEmbeddable = metaModel.isEmbeddable(attrib.getBindableJavaType());
+                isAssociation = attrib.isAssociation();
+                dbColName += ("." + attrib.getJPAColumnName());
+            }
+            else if (isAssociation)
+            {
+                String attName = pathExp.getPath(count++);
+                fieldName = fieldName + "." + attName;
+                EntityType associatedType = metaModel.entity(attrib.getBindableJavaType());
+                attrib = (AbstractAttribute) associatedType.getAttribute(attName);
+                isEmbeddable = metaModel.isEmbeddable(attrib.getBindableJavaType());
+                isAssociation = attrib.isAssociation();
                 dbColName += ("." + attrib.getJPAColumnName());
             }
             colName = fieldName;

--- a/src/kundera-mongo/src/main/java/com/impetus/client/mongodb/MongoDBClient.java
+++ b/src/kundera-mongo/src/main/java/com/impetus/client/mongodb/MongoDBClient.java
@@ -1641,7 +1641,7 @@ public class MongoDBClient extends ClientBase implements Client<MongoDBQuery>, B
         {
             entities = executeNativeQuery(jsonClause, entityMetadata);
             List result = new ArrayList();
-            if (entities.get(0) instanceof EnhanceEntity)
+            if (entities.size() > 0 && (entities.get(0) instanceof EnhanceEntity))
             {
                 for (Object obj : entities)
                 {

--- a/src/kundera-mongo/src/main/java/com/impetus/client/mongodb/query/MongoDBQuery.java
+++ b/src/kundera-mongo/src/main/java/com/impetus/client/mongodb/query/MongoDBQuery.java
@@ -575,7 +575,7 @@ public class MongoDBQuery extends QueryImpl
 
                             if (value instanceof String)
                             {
-                                value = Pattern.compile(createLikeRegex((String) value));
+                                value = Pattern.compile(createLikeRegex((String) value, ignoreCase));
 
                             }
                             else if (value instanceof Collection)
@@ -585,7 +585,7 @@ public class MongoDBQuery extends QueryImpl
 
                                 for (Object item : original)
                                 {
-                                    values.add(Pattern.compile(createLikeRegex((String) item)));
+                                    values.add(Pattern.compile(createLikeRegex((String) item, ignoreCase)));
                                 }
 
                                 value = values;
@@ -602,7 +602,7 @@ public class MongoDBQuery extends QueryImpl
                     else if (condition.toLowerCase().contains("like"))
                     {
 
-                        Pattern regEx = Pattern.compile(createLikeRegex((String) value));
+                        Pattern regEx = Pattern.compile(createLikeRegex((String) value, ignoreCase));
                         boolean negative = condition.toLowerCase().contains("not");
 
                         if (query.containsField(property))
@@ -980,11 +980,13 @@ public class MongoDBQuery extends QueryImpl
      * 
      * @param expr
      *            the expr
+     * @param ignoreCase
+     *            whether to ignore the case
      * @return the string
      */
-    public static String createLikeRegex(String expr)
+    public static String createLikeRegex(String expr, boolean ignoreCase)
     {
-        String regex = createRegex(expr);
+        String regex = createRegex(expr, ignoreCase);
         regex = regex.replace("_", ".").replace("%", ".*?");
 
         return regex;
@@ -995,9 +997,11 @@ public class MongoDBQuery extends QueryImpl
      * 
      * @param value
      *            the value
+     * @param ignoreCase
+     *            whether to ignore the case
      * @return the string
      */
-    public static String createRegex(String value)
+    public static String createRegex(String value, boolean ignoreCase)
     {
         if (value == null)
         {
@@ -1011,7 +1015,13 @@ public class MongoDBQuery extends QueryImpl
         }
 
         StringBuilder sb = new StringBuilder(len * 2);
-        sb.append("(?i)^");
+
+        if (ignoreCase) {
+            sb.append("(?i)");
+        }
+
+        sb.append("^");
+
         for (int i = 0; i < len; i++)
         {
             char c = value.charAt(i);

--- a/src/kundera-mongo/src/main/java/com/impetus/client/mongodb/query/MongoDBQuery.java
+++ b/src/kundera-mongo/src/main/java/com/impetus/client/mongodb/query/MongoDBQuery.java
@@ -565,9 +565,19 @@ public class MongoDBQuery extends QueryImpl
                         {
                             Relation relation = m.getRelation(embeddedAttributeAsStr);
                             f = relation.getProperty();
-                            if (!kunderaQuery.isAggregated())
+
+                            AbstractAttribute targetAttribute = (AbstractAttribute) metaModel
+                                  .entity(relation.getTargetEntity()).getAttribute(embeddableAttributeAsStr);
+                            String targetColumnName = targetAttribute.getJPAColumnName();
+
+                            if (targetAttribute instanceof DefaultSingularAttribute &&
+                                  ((DefaultSingularAttribute) targetAttribute).isId())
                             {
                                 property = relation.getJoinColumnName(kunderaMetadata);
+                            }
+                            else
+                            {
+                                property = embeddedAttributeAsStr + "." + targetColumnName;
                             }
                         }
                         else

--- a/src/kundera-mongo/src/main/java/com/impetus/client/mongodb/query/MongoDBQuery.java
+++ b/src/kundera-mongo/src/main/java/com/impetus/client/mongodb/query/MongoDBQuery.java
@@ -976,6 +976,10 @@ public class MongoDBQuery extends QueryImpl
                 {
                     actualColumnName = "metadata." + columnName;
                 }
+                else if (metadata.getIdAttribute().equals(entityType.getAttribute(columnName)))
+                {
+                    actualColumnName = "_id";
+                }
 
                 BasicDBObject item = new BasicDBObject("$" + identifier, "$" + actualColumnName);
                 group.put(identifier + "_" + columnName, item);

--- a/src/kundera-mongo/src/main/java/com/impetus/client/mongodb/query/MongoDBQuery.java
+++ b/src/kundera-mongo/src/main/java/com/impetus/client/mongodb/query/MongoDBQuery.java
@@ -19,6 +19,7 @@ import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -704,11 +705,27 @@ public class MongoDBQuery extends QueryImpl
                     else if (condition.equalsIgnoreCase("in"))
                     {
 
+                        if (value != null)
+                        {
+                            if (!value.getClass().isArray() && !(value instanceof Collection))
+                            {
+                                value = Collections.singletonList(value);
+                            }
+                        }
+
                         appendToQuery(query, property, "$in", value);
 
                     }
                     else if (condition.equalsIgnoreCase("not in"))
                     {
+
+                        if (value != null)
+                        {
+                            if (!value.getClass().isArray() && !(value instanceof Collection))
+                            {
+                                value = Collections.singletonList(value);
+                            }
+                        }
 
                         appendToQuery(query, property, "$nin", value);
 

--- a/src/kundera-mongo/src/main/java/com/impetus/client/mongodb/query/gfs/KunderaGridFS.java
+++ b/src/kundera-mongo/src/main/java/com/impetus/client/mongodb/query/gfs/KunderaGridFS.java
@@ -16,6 +16,7 @@
 
 package com.impetus.client.mongodb.query.gfs;
 
+import com.mongodb.AggregationOutput;
 import com.mongodb.DB;
 import com.mongodb.DBCursor;
 import com.mongodb.DBObject;
@@ -100,6 +101,17 @@ public class KunderaGridFS extends GridFS
             }
         }
         return files;
+    }
+
+    /**
+     * MongoDB aggregation.
+     *
+     * @param pipeline
+     * @return
+     */
+    public AggregationOutput aggregate(List<DBObject> pipeline)
+    {
+        return _filesCollection.aggregate(pipeline);
     }
 
 }

--- a/src/kundera-mongo/src/main/java/com/impetus/client/mongodb/utils/MongoDBUtils.java
+++ b/src/kundera-mongo/src/main/java/com/impetus/client/mongodb/utils/MongoDBUtils.java
@@ -9,8 +9,10 @@ import java.math.BigInteger;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.sql.Date;
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
@@ -18,6 +20,9 @@ import javax.persistence.metamodel.Attribute;
 import javax.persistence.metamodel.EmbeddableType;
 import javax.xml.bind.DatatypeConverter;
 
+import org.eclipse.persistence.jpa.jpql.parser.CollectionExpression;
+import org.eclipse.persistence.jpa.jpql.parser.Expression;
+import org.eclipse.persistence.jpa.jpql.parser.StringLiteral;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -125,6 +130,22 @@ public class MongoDBUtils
         else if ((valObj instanceof Calendar) || (valObj instanceof GregorianCalendar))
         {
             return ((Calendar) valObj).getTime();
+        }
+        else if (CollectionExpression.class.isAssignableFrom(clazz))
+        {
+            CollectionExpression collExpr = (CollectionExpression) valObj;
+            List<String> texts = new ArrayList<String>(collExpr.childrenSize());
+
+            for (Expression childExpr : collExpr.orderedChildren())
+            {
+                if (childExpr instanceof StringLiteral)
+                {
+                    StringLiteral stringLiteral = (StringLiteral) childExpr;
+                    texts.add(stringLiteral.getUnquotedText());
+                }
+            }
+
+            return texts;
         }
         return valObj;
     }

--- a/src/kundera-mongo/src/test/java/com/impetus/client/crud/ArticleGFSTest.java
+++ b/src/kundera-mongo/src/test/java/com/impetus/client/crud/ArticleGFSTest.java
@@ -1,0 +1,320 @@
+/*******************************************************************************
+ * * Copyright 2012 Impetus Infotech.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ ******************************************************************************/
+package com.impetus.client.crud;
+
+import com.impetus.client.crud.entities.ArticleGFS;
+import com.impetus.client.utils.MongoUtils;
+import junit.framework.Assert;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Persistence;
+import javax.persistence.Query;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * The Class ArticleGFSTest.
+ */
+public class ArticleGFSTest
+{
+
+    /** The Constant _PU. */
+    private static final String _PU = "mongoTest";
+
+    /** The emf. */
+    private static EntityManagerFactory emf;
+
+    /** The em. */
+    private static EntityManager em;
+
+    /**
+     * Sets the up.
+     * 
+     * @throws Exception
+     *             the exception
+     */
+    @Before
+    public void setUp() throws Exception
+    {
+        emf = Persistence.createEntityManagerFactory(_PU);
+        em = emf.createEntityManager();
+    }
+
+    /**
+     * Tear down.
+     * 
+     * @throws Exception
+     *             the exception
+     */
+    @After
+    public void tearDown() throws Exception
+    {
+        em.close();
+        MongoUtils.dropDatabase(emf, _PU);
+        emf.close();
+    }
+
+    @Test
+    public void testComplexQueries()
+    {
+        prepareArticle("article1", date("2017-01-05 10:00"), date("2017-01-05 10:00"), "First article", "important", 0, true);
+        prepareArticle("article2", date("2017-01-15 10:00"), date("2017-01-15 10:00"), "Second article", null, 0, true);
+        prepareArticle("article3", date("2017-01-25 10:00"), date("2017-01-25 10:00"), "Third article", "important", 0, true);
+        prepareArticle("article4", date("2017-01-30 10:00"), null, "Fourth article", "important", 0, true);
+        prepareArticle("article5", date("2017-02-05 10:00"), date("2017-02-55 10:00"), "Fifth article", null, 0, true);
+
+        Query query = em.createQuery(
+              "select a from ArticleGFS a where a.show = :show and " +
+                    "(a.displayDate is null or a.displayDate < :date1 or a.displayDate > :date2) " +
+                    "order by a.createDate asc");
+        query.setParameter("show", true);
+        query.setParameter("date1", date("2017-01-20 00:00"));
+        query.setParameter("date2", date("2017-02-01 00:00"));
+        List<ArticleGFS> results = query.getResultList();
+
+        Assert.assertNotNull(results);
+        Assert.assertEquals(4, results.size());
+        Assert.assertEquals("First article", results.get(0).getTitle());
+        Assert.assertEquals("Second article", results.get(1).getTitle());
+        Assert.assertEquals("Fourth article", results.get(2).getTitle());
+        Assert.assertEquals("Fifth article", results.get(3).getTitle());
+
+        query = em.createQuery(
+              "select a from ArticleGFS a where a.show = :show and " +
+                    "(a.displayDate is null or a.displayDate < :date1 or a.displayDate > :date2 and a.category is null) " +
+                    "order by a.createDate asc");
+        query.setParameter("show", true);
+        query.setParameter("date1", date("2017-01-20 00:00"));
+        query.setParameter("date2", date("2017-02-01 00:00"));
+        results = query.getResultList();
+
+        Assert.assertNotNull(results);
+        Assert.assertEquals(4, results.size());
+        Assert.assertEquals("First article", results.get(0).getTitle());
+        Assert.assertEquals("Second article", results.get(1).getTitle());
+        Assert.assertEquals("Fourth article", results.get(2).getTitle());
+        Assert.assertEquals("Fifth article", results.get(3).getTitle());
+
+        query = em.createQuery(
+              "select a from ArticleGFS a where a.show = :show and " +
+                    "(a.displayDate > :date2 and a.category is null or a.displayDate is null or a.displayDate < :date1) " +
+                    "order by a.createDate asc");
+        query.setParameter("show", true);
+        query.setParameter("date1", date("2017-01-20 00:00"));
+        query.setParameter("date2", date("2017-02-01 00:00"));
+        results = query.getResultList();
+
+        Assert.assertNotNull(results);
+        Assert.assertEquals(4, results.size());
+        Assert.assertEquals("First article", results.get(0).getTitle());
+        Assert.assertEquals("Second article", results.get(1).getTitle());
+        Assert.assertEquals("Fourth article", results.get(2).getTitle());
+        Assert.assertEquals("Fifth article", results.get(3).getTitle());
+
+        query = em.createQuery(
+              "select a from ArticleGFS a where a.show = :show and " +
+                    "(a.category is null and (a.displayDate > :date2 or a.displayDate is null or a.displayDate < :date1)) " +
+                    "order by a.createDate asc");
+        query.setParameter("show", true);
+        query.setParameter("date1", date("2017-01-20 00:00"));
+        query.setParameter("date2", date("2017-02-01 00:00"));
+        results = query.getResultList();
+
+        Assert.assertNotNull(results);
+        Assert.assertEquals(2, results.size());
+        Assert.assertEquals("Second article", results.get(0).getTitle());
+        Assert.assertEquals("Fifth article", results.get(1).getTitle());
+
+        query = em.createQuery(
+              "select a from ArticleGFS a where a.show = :show and " +
+                    "(a.createDate < :date and (a.displayDate is null or a.displayDate < :date)) " +
+                    "and a.category = :category " +
+                    "order by a.createDate asc");
+        query.setParameter("show", true);
+        query.setParameter("date", date("2017-03-30 00:00"));
+        query.setParameter("category", "important");
+        results = query.getResultList();
+
+        Assert.assertNotNull(results);
+        Assert.assertEquals(3, results.size());
+        Assert.assertEquals("First article", results.get(0).getTitle());
+        Assert.assertEquals("Third article", results.get(1).getTitle());
+        Assert.assertEquals("Fourth article", results.get(2).getTitle());
+    }
+
+    @Test
+    public void testAggregation()
+    {
+        prepareArticle("article1", date("2017-01-05 10:00"), null, "First article", "A", 1, true);
+        prepareArticle("article2", date("2017-01-15 10:00"), null, "Second article", "B", 3, true);
+        prepareArticle("article3", date("2017-01-25 10:00"), null, "Third article", "A", 6, true);
+
+        Query query = em.createQuery("select max(a.priority) from ArticleGFS a");
+        List<?> results = query.getResultList();
+
+        Assert.assertNotNull(results);
+        Assert.assertEquals(1, results.size());
+        Assert.assertEquals(6, results.get(0));
+
+        query = em.createQuery("select max(a.priority), min(a.priority) from ArticleGFS a");
+        results = query.getResultList();
+
+        Assert.assertNotNull(results);
+        Assert.assertEquals(1, results.size());
+
+        Object[] resultArray = (Object[]) results.get(0);
+        Assert.assertEquals("Results: " + Arrays.toString(resultArray), 2, resultArray.length);
+        Assert.assertEquals(6, resultArray[0]);
+        Assert.assertEquals(1, resultArray[1]);
+
+        query = em.createQuery("select avg(a.priority), sum(a.priority), max(a.priority), min(a.priority) from ArticleGFS a");
+        results = query.getResultList();
+
+        Assert.assertNotNull(results);
+        Assert.assertEquals(1, results.size());
+
+        resultArray = (Object[]) results.get(0);
+        Assert.assertEquals("Results: " + Arrays.toString(resultArray), 4, resultArray.length);
+        assertAlmostEqual(3.3333, resultArray[0]);
+        Assert.assertEquals(10, resultArray[1]);
+        Assert.assertEquals(6, resultArray[2]);
+        Assert.assertEquals(1, resultArray[3]);
+
+        query = em.createQuery("select sum(a.priority), a.category from ArticleGFS a group by a.category order by a.category");
+        results = query.getResultList();
+
+        Assert.assertNotNull(results);
+        Assert.assertEquals(2, results.size());
+        Assert.assertEquals("A", ((Object[]) results.get(0))[1]);
+        Assert.assertEquals("B", ((Object[]) results.get(1))[1]);
+
+        for (Object item : results)
+        {
+            resultArray = (Object[]) item;
+            Assert.assertEquals("Result Item: " + Arrays.toString(resultArray), 2, resultArray.length);
+            Assert.assertTrue(Arrays.asList("A", "B").contains(resultArray[1]));
+
+            if (resultArray[1].equals("A"))
+            {
+                Assert.assertEquals(7, resultArray[0]);
+            }
+            else if (resultArray[1].equals("B"))
+            {
+                Assert.assertEquals(3, resultArray[0]);
+            }
+        }
+
+        query = em.createQuery("select sum(a.priority), a.category, avg(a.priority), min(a.priority) from ArticleGFS a group by a.category");
+        results = query.getResultList();
+
+        Assert.assertNotNull(results);
+        Assert.assertEquals(2, results.size());
+        assertSumsMatch(results, 4);
+
+        query = em.createQuery("select sum(a.priority), a.category from ArticleGFS a group by a.category order by sum(a.priority) desc");
+        results = query.getResultList();
+
+        Assert.assertNotNull(results);
+        Assert.assertEquals(2, results.size());
+        Assert.assertEquals("A", ((Object[]) results.get(0))[1]);
+        Assert.assertEquals("B", ((Object[]) results.get(1))[1]);
+        assertSumsMatch(results, 2);
+    }
+
+    @Test
+    public void testCountAggregation()
+    {
+        prepareArticle("article1", date("2017-01-05 10:00"), null, "First article", "A", 1, true);
+        prepareArticle("article2", date("2017-01-15 10:00"), null, "Second article", "B", 3, true);
+        prepareArticle("article3", date("2017-01-25 10:00"), null, "Third article", "A", 6, true);
+
+        Query query = em.createQuery("select sum(a.priority), count(a), a.category from ArticleGFS a group by a.category order by a.category");
+        List results = query.getResultList();
+
+        Assert.assertNotNull(results);
+        Assert.assertEquals(2, results.size());
+        Assert.assertEquals(2L, ((Object[]) results.get(0))[1]);
+        Assert.assertEquals(1L, ((Object[]) results.get(1))[1]);
+
+        query = em.createQuery("select count(a) from ArticleGFS a");
+        Object result = query.getSingleResult();
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(3L, result);
+    }
+
+    private void assertAlmostEqual(double expected, Object actual)
+    {
+        double value = (double) actual;
+        Assert.assertTrue(String.format("%.4f != %.4f\nExpected: %.4f\nActual  : %.4f", expected, value, expected, value),
+              Math.abs(value - expected) < 0.0001);
+    }
+
+    private void assertSumsMatch(List results, int expectedNumberOfItems)
+    {
+        for (Object item : results)
+        {
+            Object[] resultArray = (Object[]) item;
+            Assert.assertEquals("Result Item: " + Arrays.toString(resultArray), expectedNumberOfItems, resultArray.length);
+            Assert.assertTrue(Arrays.asList("A", "B").contains(resultArray[1]));
+
+            if (resultArray[1].equals("A"))
+            {
+                Assert.assertEquals(7, resultArray[0]);
+            }
+            else if (resultArray[1].equals("B"))
+            {
+                Assert.assertEquals(3, resultArray[0]);
+            }
+        }
+    }
+
+    private void prepareArticle(String id, Date createDate, Date displayDate,
+                                String title, String category, int priority, boolean show)
+    {
+        ArticleGFS item = new ArticleGFS();
+        item.setArticleId(id);
+        item.setCreateDate(createDate);
+        item.setDisplayDate(displayDate);
+        item.setTitle(title);
+        item.setCategory(category);
+        item.setPriority(priority);
+        item.setShow(show);
+        item.setData("TestData".getBytes());
+        em.persist(item);
+    }
+
+    private static Date date(String value)
+    {
+        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm");
+        try
+        {
+            return format.parse(value);
+        }
+        catch (ParseException ex)
+        {
+            throw new AssertionError("Invalid date: " + value, ex);
+        }
+    }
+
+}

--- a/src/kundera-mongo/src/test/java/com/impetus/client/crud/ArticleMongoTest.java
+++ b/src/kundera-mongo/src/test/java/com/impetus/client/crud/ArticleMongoTest.java
@@ -31,6 +31,7 @@ import javax.persistence.Query;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
@@ -155,6 +156,18 @@ public class ArticleMongoTest
         query.setParameter("show", true);
         query.setParameter("date", date("2017-03-30 00:00"));
         query.setParameter("category", "important");
+        results = query.getResultList();
+
+        Assert.assertNotNull(results);
+        Assert.assertEquals(3, results.size());
+        Assert.assertEquals("First article", results.get(0).getTitle());
+        Assert.assertEquals("Third article", results.get(1).getTitle());
+        Assert.assertEquals("Fourth article", results.get(2).getTitle());
+
+        query = em.createQuery(
+              "select a from ArticleMongo a where a.category IN :category " +
+                    "order by a.createDate asc");
+        query.setParameter("category", Collections.singletonList("important"));
         results = query.getResultList();
 
         Assert.assertNotNull(results);

--- a/src/kundera-mongo/src/test/java/com/impetus/client/crud/ArticleMongoTest.java
+++ b/src/kundera-mongo/src/test/java/com/impetus/client/crud/ArticleMongoTest.java
@@ -1,0 +1,190 @@
+/*******************************************************************************
+ * * Copyright 2012 Impetus Infotech.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ ******************************************************************************/
+package com.impetus.client.crud;
+
+import com.impetus.client.crud.entities.ArticleMongo;
+import com.impetus.client.utils.MongoUtils;
+import junit.framework.Assert;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Persistence;
+import javax.persistence.Query;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * The Class ArticleMongoTest.
+ */
+public class ArticleMongoTest
+{
+
+    /** The Constant _PU. */
+    private static final String _PU = "mongoTest";
+
+    /** The emf. */
+    private static EntityManagerFactory emf;
+
+    /** The em. */
+    private static EntityManager em;
+
+    /**
+     * Sets the up.
+     * 
+     * @throws Exception
+     *             the exception
+     */
+    @Before
+    public void setUp() throws Exception
+    {
+        emf = Persistence.createEntityManagerFactory(_PU);
+        em = emf.createEntityManager();
+    }
+
+    /**
+     * Tear down.
+     * 
+     * @throws Exception
+     *             the exception
+     */
+    @After
+    public void tearDown() throws Exception
+    {
+        em.close();
+        MongoUtils.dropDatabase(emf, _PU);
+        emf.close();
+    }
+
+    @Test
+    public void testComplexQueries() {
+        prepareArticle("article1", date("2017-01-05 10:00"), date("2017-01-05 10:00"), "First article", "important", 0, true);
+        prepareArticle("article2", date("2017-01-15 10:00"), date("2017-01-15 10:00"), "Second article", null, 0, true);
+        prepareArticle("article3", date("2017-01-25 10:00"), date("2017-01-25 10:00"), "Third article", "important", 0, true);
+        prepareArticle("article4", date("2017-01-30 10:00"), null, "Fourth article", "important", 0, true);
+        prepareArticle("article5", date("2017-02-05 10:00"), date("2017-02-55 10:00"), "Fifth article", null, 0, true);
+
+        Query query = em.createQuery(
+              "select a from ArticleMongo a where a.show = :show and " +
+                    "(a.displayDate is null or a.displayDate < :date1 or a.displayDate > :date2) " +
+                    "order by a.createDate asc");
+        query.setParameter("show", true);
+        query.setParameter("date1", date("2017-01-20 00:00"));
+        query.setParameter("date2", date("2017-02-01 00:00"));
+        List<ArticleMongo> results = query.getResultList();
+
+        Assert.assertNotNull(results);
+        Assert.assertEquals(4, results.size());
+        Assert.assertEquals("First article", results.get(0).getTitle());
+        Assert.assertEquals("Second article", results.get(1).getTitle());
+        Assert.assertEquals("Fourth article", results.get(2).getTitle());
+        Assert.assertEquals("Fifth article", results.get(3).getTitle());
+
+        query = em.createQuery(
+              "select a from ArticleMongo a where a.show = :show and " +
+                    "(a.displayDate is null or a.displayDate < :date1 or a.displayDate > :date2 and a.category is null) " +
+                    "order by a.createDate asc");
+        query.setParameter("show", true);
+        query.setParameter("date1", date("2017-01-20 00:00"));
+        query.setParameter("date2", date("2017-02-01 00:00"));
+        results = query.getResultList();
+
+        Assert.assertNotNull(results);
+        Assert.assertEquals(4, results.size());
+        Assert.assertEquals("First article", results.get(0).getTitle());
+        Assert.assertEquals("Second article", results.get(1).getTitle());
+        Assert.assertEquals("Fourth article", results.get(2).getTitle());
+        Assert.assertEquals("Fifth article", results.get(3).getTitle());
+
+        query = em.createQuery(
+              "select a from ArticleMongo a where a.show = :show and " +
+                    "(a.displayDate > :date2 and a.category is null or a.displayDate is null or a.displayDate < :date1) " +
+                    "order by a.createDate asc");
+        query.setParameter("show", true);
+        query.setParameter("date1", date("2017-01-20 00:00"));
+        query.setParameter("date2", date("2017-02-01 00:00"));
+        results = query.getResultList();
+
+        Assert.assertNotNull(results);
+        Assert.assertEquals(4, results.size());
+        Assert.assertEquals("First article", results.get(0).getTitle());
+        Assert.assertEquals("Second article", results.get(1).getTitle());
+        Assert.assertEquals("Fourth article", results.get(2).getTitle());
+        Assert.assertEquals("Fifth article", results.get(3).getTitle());
+
+        query = em.createQuery(
+              "select a from ArticleMongo a where a.show = :show and " +
+                    "(a.category is null and (a.displayDate > :date2 or a.displayDate is null or a.displayDate < :date1)) " +
+                    "order by a.createDate asc");
+        query.setParameter("show", true);
+        query.setParameter("date1", date("2017-01-20 00:00"));
+        query.setParameter("date2", date("2017-02-01 00:00"));
+        results = query.getResultList();
+
+        Assert.assertNotNull(results);
+        Assert.assertEquals(2, results.size());
+        Assert.assertEquals("Second article", results.get(0).getTitle());
+        Assert.assertEquals("Fifth article", results.get(1).getTitle());
+
+        query = em.createQuery(
+              "select a from ArticleMongo a where a.show = :show and " +
+                    "(a.createDate < :date and (a.displayDate is null or a.displayDate < :date)) " +
+                    "and a.category = :category " +
+                    "order by a.createDate asc");
+        query.setParameter("show", true);
+        query.setParameter("date", date("2017-03-30 00:00"));
+        query.setParameter("category", "important");
+        results = query.getResultList();
+
+        Assert.assertNotNull(results);
+        Assert.assertEquals(3, results.size());
+        Assert.assertEquals("First article", results.get(0).getTitle());
+        Assert.assertEquals("Third article", results.get(1).getTitle());
+        Assert.assertEquals("Fourth article", results.get(2).getTitle());
+    }
+
+    private void prepareArticle(String id, Date createDate, Date displayDate,
+                                String title, String category, int priority, boolean show)
+    {
+        ArticleMongo item = new ArticleMongo();
+        item.setArticleId(id);
+        item.setCreateDate(createDate);
+        item.setDisplayDate(displayDate);
+        item.setTitle(title);
+        item.setCategory(category);
+        item.setPriority(priority);
+        item.setShow(show);
+        em.persist(item);
+    }
+
+    private static Date date(String value)
+    {
+        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm");
+        try
+        {
+            return format.parse(value);
+        }
+        catch (ParseException ex)
+        {
+            throw new AssertionError("Invalid date: " + value, ex);
+        }
+    }
+
+}

--- a/src/kundera-mongo/src/test/java/com/impetus/client/crud/ArticleMongoTest.java
+++ b/src/kundera-mongo/src/test/java/com/impetus/client/crud/ArticleMongoTest.java
@@ -209,13 +209,16 @@ public class ArticleMongoTest
         Assert.assertEquals("article2", results.get(3).getArticle().getArticleId());
         Assert.assertNull(results.get(3).getDetails());
 
-        query = em.createQuery("select e from ArticleMTO e where e.article.priority > 2");
+        query = em.createQuery("select e from ArticleMTO e where e.article.articleId in :ids order by e.id");
+        query.setParameter("ids", Arrays.asList("article2", "article3"));
         results = query.getResultList();
 
         Assert.assertNotNull(results);
         Assert.assertEquals(2, results.size());
-        Assert.assertTrue(Arrays.asList("ext3", "ext4").contains(results.get(0).getId()));
-        Assert.assertTrue(Arrays.asList("ext3", "ext4").contains(results.get(1).getId()));
+        Assert.assertEquals("ext3", results.get(0).getId());
+        Assert.assertEquals("article3", results.get(0).getArticle().getArticleId());
+        Assert.assertEquals("ext4", results.get(1).getId());
+        Assert.assertEquals("article2", results.get(1).getArticle().getArticleId());
     }
 
     @Test

--- a/src/kundera-mongo/src/test/java/com/impetus/client/crud/ArticleMongoTest.java
+++ b/src/kundera-mongo/src/test/java/com/impetus/client/crud/ArticleMongoTest.java
@@ -219,6 +219,13 @@ public class ArticleMongoTest
         Assert.assertEquals("article3", results.get(0).getArticle().getArticleId());
         Assert.assertEquals("ext4", results.get(1).getId());
         Assert.assertEquals("article2", results.get(1).getArticle().getArticleId());
+
+        query = em.createQuery("select max(e.value) from ArticleMTO e where e.article.priority < :priority");
+        query.setParameter("priority", 5);
+        Object singleResult = query.getSingleResult();
+
+        Assert.assertNotNull(singleResult);
+        Assert.assertEquals(30L, singleResult);
     }
 
     @Test

--- a/src/kundera-mongo/src/test/java/com/impetus/client/crud/BaseTest.java
+++ b/src/kundera-mongo/src/test/java/com/impetus/client/crud/BaseTest.java
@@ -298,7 +298,7 @@ public abstract class BaseTest
         results = q.getResultList();
         Assert.assertEquals(0, results.size());
         
-        q = em.createQuery("Select p from " + clazz + " p where p." + fieldName + " like :name");
+        q = em.createQuery("Select p from " + clazz + " p where UPPER(p." + fieldName + ") like :name");
         q.setParameter("name", "MC.JOHN DOE");
         results = q.getResultList();
         Assert.assertEquals(1, results.size());
@@ -334,7 +334,7 @@ public abstract class BaseTest
         results = q.getResultList();
         Assert.assertEquals(0, results.size());
         
-        q = em.createQuery("Select p from " + clazz + " p where p." + fieldName + " like :name");
+        q = em.createQuery("Select p from " + clazz + " p where UPPER(p." + fieldName + ") like :name");
         q.setParameter("name", "MC_%");
         results = q.getResultList();
         Assert.assertEquals(1, results.size());

--- a/src/kundera-mongo/src/test/java/com/impetus/client/crud/PersonMongoTest.java
+++ b/src/kundera-mongo/src/test/java/com/impetus/client/crud/PersonMongoTest.java
@@ -749,7 +749,8 @@ public class PersonMongoTest extends BaseTest
         q.setParameter("personId", "1");
         List<PersonMongo> results = q.getResultList();
         Assert.assertNotNull(results);
-        Assert.assertEquals(0, results.size());
+        Assert.assertEquals(1, results.size());
+        Assert.assertEquals("1", results.get(0).getPersonId());
 
         query = "Select p from PersonMongo p where (p.personName = :name AND p.age NOT IN :ageList)"
                 + " OR (p.personId = :personId)";

--- a/src/kundera-mongo/src/test/java/com/impetus/client/crud/PersonMongoTest.java
+++ b/src/kundera-mongo/src/test/java/com/impetus/client/crud/PersonMongoTest.java
@@ -869,6 +869,111 @@ public class PersonMongoTest extends BaseTest
         executeMapReduceTest(query);
     }
 
+    @Test
+    public void testUpperAndLower()
+    {
+        Object p1 = prepareMongoInstance("alexander", 10);
+        Object p2 = prepareMongoInstance("sandra", 20);
+        Object p3 = prepareMongoInstance("CASSANDRA", 15);
+        em.persist(p1);
+        em.persist(p2);
+        em.persist(p3);
+
+        String query = "Select p from PersonMongo p where UPPER(p.personId) = 'SANDRA'";
+        Query q = em.createQuery(query);
+        List<PersonMongo> results = q.getResultList();
+        Assert.assertNotNull(results);
+        Assert.assertEquals(1, results.size());
+
+        query = "Select p from PersonMongo p where LOWER(p.personId) = 'cassandra'";
+        q = em.createQuery(query);
+        results = q.getResultList();
+        Assert.assertNotNull(results);
+        Assert.assertEquals(1, results.size());
+
+        query = "Select p from PersonMongo p where LOWER(p.personId) IN ('sandra', 'cassandra')";
+        q = em.createQuery(query);
+        results = q.getResultList();
+        Assert.assertNotNull(results);
+        Assert.assertEquals(2, results.size());
+
+        query = "Select p from PersonMongo p where LOWER(p.personId) NOT IN ('sandra', 'cassandra')";
+        q = em.createQuery(query);
+        results = q.getResultList();
+        Assert.assertNotNull(results);
+        Assert.assertEquals(1, results.size());
+
+        query = "Select p from PersonMongo p where UPPER(p.personId) <> 'ALEXANDER'";
+        q = em.createQuery(query);
+        results = q.getResultList();
+        Assert.assertNotNull(results);
+        Assert.assertEquals(2, results.size());
+    }
+
+    @Test
+    public void testLikeAndUpperLower()
+    {
+        Object p1 = prepareMongoInstance("alexander", 10);
+        Object p2 = prepareMongoInstance("sandra", 20);
+        Object p3 = prepareMongoInstance("CASSANDRA", 15);
+        em.persist(p1);
+        em.persist(p2);
+        em.persist(p3);
+
+        String query = "Select p from PersonMongo p where p.personId LIKE '%and%'";
+        Query q = em.createQuery(query);
+        List<PersonMongo> results = q.getResultList();
+        Assert.assertNotNull(results);
+        Assert.assertEquals(3, results.size());
+
+        query = "Select p from PersonMongo p where UPPER(p.personId) LIKE '%and%'";
+        q = em.createQuery(query);
+        results = q.getResultList();
+        Assert.assertNotNull(results);
+        Assert.assertEquals(3, results.size());
+
+        query = "Select p from PersonMongo p where LOWER(p.personId) LIKE '%and%'";
+        q = em.createQuery(query);
+        results = q.getResultList();
+        Assert.assertNotNull(results);
+        Assert.assertEquals(3, results.size());
+    }
+
+    @Test
+    public void testNotLike()
+    {
+        Object p1 = prepareMongoInstance("alexander", 10);
+        Object p2 = prepareMongoInstance("sandra", 20);
+        Object p3 = prepareMongoInstance("CASSANDRA", 15);
+        em.persist(p1);
+        em.persist(p2);
+        em.persist(p3);
+
+        String query = "Select p from PersonMongo p where p.personId NOT LIKE '%andr%'";
+        Query q = em.createQuery(query);
+        List<PersonMongo> results = q.getResultList();
+        Assert.assertNotNull(results);
+        Assert.assertEquals(1, results.size());
+
+        query = "Select p from PersonMongo p where p.personId NOT LIKE '%andr%' AND p.personId = 'alexander'";
+        q = em.createQuery(query);
+        results = q.getResultList();
+        Assert.assertNotNull(results);
+        Assert.assertEquals(1, results.size());
+
+        query = "Select p from PersonMongo p where p.personId = 'alexander' AND p.personId NOT LIKE '%andr%'";
+        q = em.createQuery(query);
+        results = q.getResultList();
+        Assert.assertNotNull(results);
+        Assert.assertEquals(1, results.size());
+
+        query = "Select p from PersonMongo p where p.personId LIKE '%lex%' AND p.personId NOT LIKE 'cass%'";
+        q = em.createQuery(query);
+        results = q.getResultList();
+        Assert.assertNotNull(results);
+        Assert.assertEquals(1, results.size());
+    }
+
     /**
      * Execute map reduce test.
      * 

--- a/src/kundera-mongo/src/test/java/com/impetus/client/crud/PersonMongoTest.java
+++ b/src/kundera-mongo/src/test/java/com/impetus/client/crud/PersonMongoTest.java
@@ -924,7 +924,7 @@ public class PersonMongoTest extends BaseTest
         Query q = em.createQuery(query);
         List<PersonMongo> results = q.getResultList();
         Assert.assertNotNull(results);
-        Assert.assertEquals(3, results.size());
+        Assert.assertEquals(2, results.size());
 
         query = "Select p from PersonMongo p where UPPER(p.personId) LIKE '%and%'";
         q = em.createQuery(query);
@@ -953,7 +953,7 @@ public class PersonMongoTest extends BaseTest
         Query q = em.createQuery(query);
         List<PersonMongo> results = q.getResultList();
         Assert.assertNotNull(results);
-        Assert.assertEquals(1, results.size());
+        Assert.assertEquals(2, results.size());
 
         query = "Select p from PersonMongo p where p.personId NOT LIKE '%andr%' AND p.personId = 'alexander'";
         q = em.createQuery(query);

--- a/src/kundera-mongo/src/test/java/com/impetus/client/crud/PersonnelEmbeddedTest.java
+++ b/src/kundera-mongo/src/test/java/com/impetus/client/crud/PersonnelEmbeddedTest.java
@@ -16,6 +16,7 @@
 package com.impetus.client.crud;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -25,6 +26,7 @@ import java.util.Set;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.Persistence;
+import javax.persistence.Query;
 
 import junit.framework.Assert;
 
@@ -174,4 +176,65 @@ public class PersonnelEmbeddedTest
        
 
     }
+
+    @Test
+    public void testAggregation()
+    {
+        PersonalDetailEmbedded embedded1 = new PersonalDetailEmbedded();
+        embedded1.setAddress("Address 1");
+        embedded1.setEmailId("email1@company.com");
+        embedded1.setPhoneNo(90001);
+        embedded1.setPhone(new PhoneDirectory("dir1",
+              Collections.singletonList("contact1"), Collections.singletonMap("contact1", "90091"),
+              Collections.singleton("90091")));
+
+        PersonnelEmbedded personnel1 = new PersonnelEmbedded();
+        personnel1.setId(1);
+        personnel1.setAge(25);
+        personnel1.setName("Person 1");
+        personnel1.setPersonalDetail(embedded1);
+
+        em.persist(personnel1);
+
+        PersonalDetailEmbedded embedded2 = new PersonalDetailEmbedded();
+        embedded2.setAddress("Address 2");
+        embedded2.setEmailId("email2@company.com");
+        embedded2.setPhoneNo(90002);
+        embedded2.setPhone(new PhoneDirectory("dir2",
+              Collections.singletonList("contact2"), Collections.singletonMap("contact2", "90092"),
+              Collections.singleton("90092")));
+
+        PersonnelEmbedded personnel2 = new PersonnelEmbedded();
+        personnel2.setId(2);
+        personnel2.setAge(32);
+        personnel2.setName("Person 2");
+        personnel2.setPersonalDetail(embedded2);
+
+        em.persist(personnel2);
+
+        Query query = em.createQuery("select max(p.id) from PersonnelEmbedded p");
+        Object result = query.getSingleResult();
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(2, result);
+
+        query = em.createQuery("select min(p.id) from PersonnelEmbedded p");
+        result = query.getSingleResult();
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(1, result);
+
+        query = em.createQuery("select avg(p.id) from PersonnelEmbedded p");
+        result = query.getSingleResult();
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(1.5, result);
+
+        query = em.createQuery("select sum(p.id) from PersonnelEmbedded p");
+        result = query.getSingleResult();
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(3, result);
+    }
+
 }

--- a/src/kundera-mongo/src/test/java/com/impetus/client/crud/datatypes/StudentMongoBooleanPrimitiveTest.java
+++ b/src/kundera-mongo/src/test/java/com/impetus/client/crud/datatypes/StudentMongoBooleanPrimitiveTest.java
@@ -229,16 +229,14 @@ public class StudentMongoBooleanPrimitiveTest extends MongoBase
             q = em.createQuery(query);
             students = q.getResultList();
             Assert.assertNotNull(students);
-            Assert.assertEquals(1, students.size());
+            Assert.assertEquals(2, students.size());
             count = 0;
             for (StudentMongoBooleanPrimitive student : students)
             {
-                Assert.assertEquals(getMaxValue(boolean.class), student.getId());
-                Assert.assertEquals(getMaxValue(short.class), student.getAge());
                 Assert.assertEquals("Kuldeep", student.getName());
                 count++;
             }
-            Assert.assertEquals(1, count);
+            Assert.assertEquals(2, count);
             em.close();
         }
         catch (QueryHandlerException qhe)

--- a/src/kundera-mongo/src/test/java/com/impetus/client/crud/datatypes/StudentMongoBooleanWrapperTest.java
+++ b/src/kundera-mongo/src/test/java/com/impetus/client/crud/datatypes/StudentMongoBooleanWrapperTest.java
@@ -40,9 +40,15 @@ public class StudentMongoBooleanWrapperTest extends MongoBase
     @After
     public void tearDown() throws Exception
     {
-        // EntityManager em = emf.createEntityManager();
-        // em.remove(em.find(StudentMongoBooleanWrapper.class,
-        // getMinValue(Boolean.class)));
+        EntityManager em = emf.createEntityManager();
+        List<StudentMongoBooleanWrapper> existingItems =
+              em.createQuery("select s from StudentMongoBooleanWrapper s").getResultList();
+
+        for (StudentMongoBooleanWrapper item : existingItems)
+        {
+            em.remove(item);
+        }
+
         emf.close();
         if (AUTO_MANAGE_SCHEMA)
         {
@@ -230,16 +236,14 @@ public class StudentMongoBooleanWrapperTest extends MongoBase
             q = em.createQuery(query);
             students = q.getResultList();
             Assert.assertNotNull(students);
-            Assert.assertEquals(1, students.size());
+            Assert.assertEquals(2, students.size());
             count = 0;
             for (StudentMongoBooleanWrapper student : students)
             {
-                Assert.assertEquals(getMaxValue(Boolean.class), student.getId());
-                Assert.assertEquals(getMaxValue(short.class), student.getAge());
                 Assert.assertEquals("Kuldeep", student.getName());
                 count++;
             }
-            Assert.assertEquals(1, count);
+            Assert.assertEquals(2, count);
             em.close();
         }
         catch (QueryHandlerException qhe)

--- a/src/kundera-mongo/src/test/java/com/impetus/client/crud/entities/ArticleDetails.java
+++ b/src/kundera-mongo/src/test/java/com/impetus/client/crud/entities/ArticleDetails.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * * Copyright 2012 Impetus Infotech.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ ******************************************************************************/
+package com.impetus.client.crud.entities;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import java.util.Date;
+
+/**
+ * The Class Article.
+ */
+@Entity
+@Table(name = "ArticleDetails", schema = "KunderaExamples@mongoTest")
+public class ArticleDetails
+{
+
+    @Id
+    @Column(name = "details_id")
+    private String id;
+
+    @Column(name = "author")
+    private String author;
+
+    @Column(name = "intro")
+    private String intro;
+
+    @Column(name = "body")
+    private String body;
+
+    public String getId()
+    {
+        return id;
+    }
+
+    public void setId(final String id)
+    {
+        this.id = id;
+    }
+
+    public String getAuthor()
+    {
+        return author;
+    }
+
+    public void setAuthor(final String author)
+    {
+        this.author = author;
+    }
+
+    public String getIntro()
+    {
+        return intro;
+    }
+
+    public void setIntro(final String intro)
+    {
+        this.intro = intro;
+    }
+
+    public String getBody()
+    {
+        return body;
+    }
+
+    public void setBody(final String body)
+    {
+        this.body = body;
+    }
+}

--- a/src/kundera-mongo/src/test/java/com/impetus/client/crud/entities/ArticleDetails.java
+++ b/src/kundera-mongo/src/test/java/com/impetus/client/crud/entities/ArticleDetails.java
@@ -22,7 +22,7 @@ import javax.persistence.Table;
 import java.util.Date;
 
 /**
- * The Class Article.
+ * The Class ArticleDetails.
  */
 @Entity
 @Table(name = "ArticleDetails", schema = "KunderaExamples@mongoTest")

--- a/src/kundera-mongo/src/test/java/com/impetus/client/crud/entities/ArticleExtension.java
+++ b/src/kundera-mongo/src/test/java/com/impetus/client/crud/entities/ArticleExtension.java
@@ -1,0 +1,50 @@
+package com.impetus.client.crud.entities;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "ArticleExtension", schema = "KunderaExamples@mongoTest")
+public class ArticleExtension
+{
+
+   @Id
+   @Column(name = "ext_id")
+   private String id;
+
+   @ManyToOne
+   @JoinColumn(name = "article_id")
+   private ArticleMongo article;
+
+   @Column(name = "artile_value")
+   private long value;
+
+   public String getId()
+   {
+      return id;
+   }
+
+   public void setId(final String id)
+   {
+      this.id = id;
+   }
+
+   public ArticleMongo getArticle()
+   {
+      return article;
+   }
+
+   public void setArticle(final ArticleMongo article)
+   {
+      this.article = article;
+   }
+
+   public long getValue()
+   {
+      return value;
+   }
+
+   public void setValue(final long value)
+   {
+      this.value = value;
+   }
+}

--- a/src/kundera-mongo/src/test/java/com/impetus/client/crud/entities/ArticleGFS.java
+++ b/src/kundera-mongo/src/test/java/com/impetus/client/crud/entities/ArticleGFS.java
@@ -1,0 +1,133 @@
+/*******************************************************************************
+ * * Copyright 2012 Impetus Infotech.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ ******************************************************************************/
+package com.impetus.client.crud.entities;
+
+import javax.persistence.*;
+import java.util.Date;
+
+/**
+ * The Class Article.
+ */
+@Entity
+@Table(name = "ArticleGFS", schema = "KunderaExamples@mongoTest")
+public class ArticleGFS
+{
+
+    @Id
+    @Column(name = "article_id")
+    private String articleId;
+
+    @Column(name = "create_date", nullable = false)
+    private Date createDate;
+
+    @Column(name = "display_date")
+    private Date displayDate;
+
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @Column(name = "category")
+    private String category;
+
+    @Column(name = "priority")
+    private int priority;
+
+    @Column(name = "show")
+    private boolean show;
+
+    @Lob
+    private byte[] data;
+
+    public String getArticleId()
+    {
+        return articleId;
+    }
+
+    public void setArticleId(final String articleId)
+    {
+        this.articleId = articleId;
+    }
+
+    public Date getCreateDate()
+    {
+        return createDate;
+    }
+
+    public void setCreateDate(final Date createDate)
+    {
+        this.createDate = createDate;
+    }
+
+    public Date getDisplayDate()
+    {
+        return displayDate;
+    }
+
+    public void setDisplayDate(final Date displayDate)
+    {
+        this.displayDate = displayDate;
+    }
+
+    public String getTitle()
+    {
+        return title;
+    }
+
+    public void setTitle(final String title)
+    {
+        this.title = title;
+    }
+
+    public String getCategory()
+    {
+        return category;
+    }
+
+    public void setCategory(final String category)
+    {
+        this.category = category;
+    }
+
+    public int getPriority()
+    {
+        return priority;
+    }
+
+    public void setPriority(final int priority)
+    {
+        this.priority = priority;
+    }
+
+    public boolean isShow()
+    {
+        return show;
+    }
+
+    public void setShow(final boolean show)
+    {
+        this.show = show;
+    }
+
+    public byte[] getData()
+    {
+        return data;
+    }
+
+    public void setData(final byte[] data)
+    {
+        this.data = data;
+    }
+}

--- a/src/kundera-mongo/src/test/java/com/impetus/client/crud/entities/ArticleGFS.java
+++ b/src/kundera-mongo/src/test/java/com/impetus/client/crud/entities/ArticleGFS.java
@@ -15,11 +15,15 @@
  ******************************************************************************/
 package com.impetus.client.crud.entities;
 
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Lob;
+import javax.persistence.Table;
 import java.util.Date;
 
 /**
- * The Class Article.
+ * The Class ArticleGFS.
  */
 @Entity
 @Table(name = "ArticleGFS", schema = "KunderaExamples@mongoTest")

--- a/src/kundera-mongo/src/test/java/com/impetus/client/crud/entities/ArticleMTO.java
+++ b/src/kundera-mongo/src/test/java/com/impetus/client/crud/entities/ArticleMTO.java
@@ -3,8 +3,8 @@ package com.impetus.client.crud.entities;
 import javax.persistence.*;
 
 @Entity
-@Table(name = "ArticleExtension", schema = "KunderaExamples@mongoTest")
-public class ArticleExtension
+@Table(name = "ArticleMTO", schema = "KunderaExamples@mongoTest")
+public class ArticleMTO
 {
 
    @Id
@@ -15,7 +15,11 @@ public class ArticleExtension
    @JoinColumn(name = "article_id")
    private ArticleMongo article;
 
-   @Column(name = "artile_value")
+   @OneToOne
+   @JoinColumn(name = "details_id")
+   private ArticleDetails details;
+
+   @Column(name = "article_value")
    private long value;
 
    public String getId()
@@ -36,6 +40,16 @@ public class ArticleExtension
    public void setArticle(final ArticleMongo article)
    {
       this.article = article;
+   }
+
+   public ArticleDetails getDetails()
+   {
+      return details;
+   }
+
+   public void setDetails(final ArticleDetails details)
+   {
+      this.details = details;
    }
 
    public long getValue()

--- a/src/kundera-mongo/src/test/java/com/impetus/client/crud/entities/ArticleMTO.java
+++ b/src/kundera-mongo/src/test/java/com/impetus/client/crud/entities/ArticleMTO.java
@@ -1,7 +1,31 @@
+/*******************************************************************************
+ * * Copyright 2012 Impetus Infotech.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ ******************************************************************************/
 package com.impetus.client.crud.entities;
 
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
 
+/**
+ * The Class ArticleMTO.
+ */
 @Entity
 @Table(name = "ArticleMTO", schema = "KunderaExamples@mongoTest")
 public class ArticleMTO

--- a/src/kundera-mongo/src/test/java/com/impetus/client/crud/entities/ArticleMongo.java
+++ b/src/kundera-mongo/src/test/java/com/impetus/client/crud/entities/ArticleMongo.java
@@ -22,7 +22,7 @@ import javax.persistence.Table;
 import java.util.Date;
 
 /**
- * The Class Article.
+ * The Class ArticleMongo.
  */
 @Entity
 @Table(name = "Article", schema = "KunderaExamples@mongoTest")

--- a/src/kundera-mongo/src/test/java/com/impetus/client/crud/entities/ArticleMongo.java
+++ b/src/kundera-mongo/src/test/java/com/impetus/client/crud/entities/ArticleMongo.java
@@ -1,0 +1,124 @@
+/*******************************************************************************
+ * * Copyright 2012 Impetus Infotech.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ ******************************************************************************/
+package com.impetus.client.crud.entities;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import java.util.Date;
+
+/**
+ * The Class Article.
+ */
+@Entity
+@Table(name = "Article", schema = "KunderaExamples@mongoTest")
+public class ArticleMongo
+{
+
+    /** The person id. */
+    @Id
+    @Column(name = "article_id")
+    private String articleId;
+
+    @Column(name = "create_date", nullable = false)
+    private Date createDate;
+
+    @Column(name = "display_date")
+    private Date displayDate;
+
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @Column(name = "category")
+    private String category;
+
+    @Column(name = "priority")
+    private int priority;
+
+    @Column(name = "show")
+    private boolean show;
+
+    public String getArticleId()
+    {
+        return articleId;
+    }
+
+    public void setArticleId(final String articleId)
+    {
+        this.articleId = articleId;
+    }
+
+    public Date getCreateDate()
+    {
+        return createDate;
+    }
+
+    public void setCreateDate(final Date createDate)
+    {
+        this.createDate = createDate;
+    }
+
+    public Date getDisplayDate()
+    {
+        return displayDate;
+    }
+
+    public void setDisplayDate(final Date displayDate)
+    {
+        this.displayDate = displayDate;
+    }
+
+    public String getTitle()
+    {
+        return title;
+    }
+
+    public void setTitle(final String title)
+    {
+        this.title = title;
+    }
+
+    public String getCategory()
+    {
+        return category;
+    }
+
+    public void setCategory(final String category)
+    {
+        this.category = category;
+    }
+
+    public int getPriority()
+    {
+        return priority;
+    }
+
+    public void setPriority(final int priority)
+    {
+        this.priority = priority;
+    }
+
+    public boolean isShow()
+    {
+        return show;
+    }
+
+    public void setShow(final boolean show)
+    {
+        this.show = show;
+    }
+}

--- a/src/kundera-mongo/src/test/java/com/impetus/client/crud/entities/ArticleMongo.java
+++ b/src/kundera-mongo/src/test/java/com/impetus/client/crud/entities/ArticleMongo.java
@@ -29,7 +29,6 @@ import java.util.Date;
 public class ArticleMongo
 {
 
-    /** The person id. */
     @Id
     @Column(name = "article_id")
     private String articleId;


### PR DESCRIPTION
Hi,

Sorry, this turned out to be a big one and I didn't break them into different commits...
What's included:

### `UPPER` and `LOWER` sets a flag on the `KunderaQuery.FilterClause` to ignore the case when evaluating the filter expression.

I've only actually implemented handling the flag in Mongo.
Without this change though the query parsing was breaking with `ClassCastException` so probably some progress even without handling the new flag explicitly in other backends?
This change also relaxes the `StateFieldPathExpression` requirement on most expressions (it's only actually needed in a couple of cases).

### MongoDB query changes

- Added support for `NOT LIKE`
- Added support for regular expressions (e.g. `LIKE` and `NOT LIKE` plus `=` and `<>`) in most cases where appropriate
- Extracting collections (for `IN` queries) from the JPQL string if not passed in as a parameter

Let me know how it looks!
All tests are passing for `kundera-core` and `kundera-mongo` but I haven't tried the other modules.

Thanks!