### PR TITLE
MongoDB configuration fixes and changes

### DIFF
--- a/src/kundera-mongo/src/main/java/com/impetus/client/mongodb/MongoDBConstants.java
+++ b/src/kundera-mongo/src/main/java/com/impetus/client/mongodb/MongoDBConstants.java
@@ -23,6 +23,9 @@ package com.impetus.client.mongodb;
 public interface MongoDBConstants
 {
 
+    /** Prefix to use with the property names below if the setting comes from external properties. */
+    public static final String EXTERNAL_CONFIGURATION_PREFIX = "kundera.mongodb.";
+
     /** The Constant CONNECTIONS. */
     public static final String CONNECTIONS = "mongodb.servers";
 

--- a/src/kundera-mongo/src/test/java/com/impetus/client/mongodb/MongoDBAddressConfigurationValidationTest.java
+++ b/src/kundera-mongo/src/test/java/com/impetus/client/mongodb/MongoDBAddressConfigurationValidationTest.java
@@ -1,0 +1,49 @@
+package com.impetus.client.mongodb;
+
+import org.junit.Test;
+
+/**
+ * Tests the MongoDB client factory configuration validation for node hostnames and ports.
+ */
+public class MongoDBAddressConfigurationValidationTest
+{
+
+   private final MongoDBClientFactory factory = new MongoDBClientFactory();
+
+   @Test
+   public void acceptsSingleHostWithDefaultPort()
+   {
+      factory.onValidation("localhost", "27017");
+   }
+
+   @Test
+   public void acceptsHostListWithDefaultPort()
+   {
+      factory.onValidation("node001,node002", "27017");
+   }
+
+   @Test
+   public void acceptsHostListWithoutDefaultPort()
+   {
+      factory.onValidation("node001:27001,node002:27002", null);
+   }
+
+   @Test(expected = IllegalArgumentException.class)
+   public void failsIfAnyHostIsMissingPortWithoutDefaultPort()
+   {
+      factory.onValidation("node001:27001,node002", null);
+   }
+
+   @Test
+   public void acceptsIPv6AddressesWithDefaultPort()
+   {
+      factory.onValidation("2001:db8:85a3::8a2e:370:7334,2001:db8::12", "27099");
+   }
+
+   @Test(expected = IllegalArgumentException.class)
+   public void failsWithIPv6AddressesWithoutDefaultPort()
+   {
+      factory.onValidation("2001:db8:85a3::8a2e:370:7334,2001:db8::12", null);
+   }
+
+}

--- a/src/kundera-mongo/src/test/java/com/impetus/kundera/client/mongo/MongoDBConfigurationTest.java
+++ b/src/kundera-mongo/src/test/java/com/impetus/kundera/client/mongo/MongoDBConfigurationTest.java
@@ -1,0 +1,350 @@
+package com.impetus.kundera.client.mongo;
+
+import com.impetus.client.crud.BaseTest;
+import com.impetus.client.mongodb.MongoDBClientFactory;
+import com.impetus.client.mongodb.MongoDBConstants;
+import com.mongodb.DBDecoder;
+import com.mongodb.DBDecoderFactory;
+import com.mongodb.DBEncoder;
+import com.mongodb.DBEncoderFactory;
+import com.mongodb.LazyDBDecoder;
+import com.mongodb.MongoClientOptions;
+import com.mongodb.WriteConcern;
+import junit.framework.Assert;
+import org.junit.Test;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import java.security.SecureRandom;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * Tests various configuration options for the MongoDB client factory.
+ */
+public class MongoDBConfigurationTest extends BaseTest
+{
+
+   /**
+    * Tests configuration from the external 'kundera.client.property' file
+    */
+   @Test
+   public void testConfigurationFromClientProperties()
+   {
+      Properties clientProperties = buildProperties(
+            kv(MongoDBConstants.SAFE, "false"));
+
+      MongoClientOptions options = buildOptions(clientProperties, null);
+
+      Assert.assertEquals(WriteConcern.NORMAL, options.getWriteConcern());
+
+      clientProperties = buildProperties(
+            kv(MongoDBConstants.W, "0"),
+            kv(MongoDBConstants.W_TIME_OUT, "1000"),
+            kv(MongoDBConstants.FSYNC, "true"),
+            kv(MongoDBConstants.J, "false"));
+
+      options = buildOptions(clientProperties, null);
+
+      WriteConcern wc = options.getWriteConcern();
+      Assert.assertEquals(0, wc.getW());
+      Assert.assertEquals(1000, wc.getWtimeout());
+      Assert.assertEquals(true, wc.getFsync());
+      Assert.assertEquals(false, wc.getJ());
+
+      clientProperties = buildProperties(
+            kv(MongoDBConstants.DB_DECODER_FACTORY, "com.mongodb.LazyDBDecoder.FACTORY"));
+
+      options = buildOptions(clientProperties, null);
+
+      Assert.assertEquals(LazyDBDecoder.FACTORY, options.getDbDecoderFactory());
+
+      clientProperties = buildProperties(
+            kv(MongoDBConstants.DB_DECODER_FACTORY, "com.impetus.kundera.client.mongo.MongoDBConfigurationTest$TestDBDecoderFactory"));
+
+      options = buildOptions(clientProperties, null);
+
+      Assert.assertEquals(TestDBDecoderFactory.class, options.getDbDecoderFactory().getClass());
+
+      clientProperties = buildProperties(
+            kv(MongoDBConstants.DB_ENCODER_FACTORY, "com.impetus.kundera.client.mongo.MongoDBConfigurationTest$TestDBEncoderFactory"));
+
+      options = buildOptions(clientProperties, null);
+
+      Assert.assertEquals(TestDBEncoderFactory.class, options.getDbEncoderFactory().getClass());
+
+      clientProperties = buildProperties(
+            kv(MongoDBConstants.SOCKET_FACTORY, "com.impetus.kundera.client.mongo.MongoDBConfigurationTest.INSECURE_SSL_SOCKET_FACTORY"));
+
+      options = buildOptions(clientProperties, null);
+
+      Assert.assertEquals(INSECURE_SSL_SOCKET_FACTORY, options.getSocketFactory());
+
+      clientProperties = buildProperties(
+            kv(MongoDBConstants.SOCKET_FACTORY, "javax.net.ssl.SSLSocketFactory.getDefault()"));
+
+      options = buildOptions(clientProperties, null);
+
+      Assert.assertEquals(SSLSocketFactory.getDefault().getClass(), options.getSocketFactory().getClass());
+
+      clientProperties = buildProperties(
+            kv(MongoDBConstants.AUTO_CONNECT_RETRY, "true"));
+
+      options = buildOptions(clientProperties, null);
+
+      Assert.assertTrue(options.isAutoConnectRetry());
+
+      clientProperties = buildProperties(
+            kv(MongoDBConstants.MAX_AUTO_CONNECT_RETRY, "12"));
+
+      options = buildOptions(clientProperties, null);
+
+      Assert.assertEquals(12L, options.getMaxAutoConnectRetryTime());
+
+      clientProperties = buildProperties(
+            kv(MongoDBConstants.CONNECTION_PER_HOST, "7"));
+
+      options = buildOptions(clientProperties, null);
+
+      Assert.assertEquals(7, options.getConnectionsPerHost());
+
+      clientProperties = buildProperties(
+            kv(MongoDBConstants.CONNECT_TIME_OUT, "32"));
+
+      options = buildOptions(clientProperties, null);
+
+      Assert.assertEquals(32, options.getConnectTimeout());
+
+      clientProperties = buildProperties(
+            kv(MongoDBConstants.MAX_WAIT_TIME, "41"));
+
+      options = buildOptions(clientProperties, null);
+
+      Assert.assertEquals(41, options.getMaxWaitTime());
+
+      clientProperties = buildProperties(
+            kv(MongoDBConstants.TABCM, "3"));
+
+      options = buildOptions(clientProperties, null);
+
+      Assert.assertEquals(3, options.getThreadsAllowedToBlockForConnectionMultiplier());
+   }
+
+   /**
+    * Tests configuration from external properties
+    */
+   @Test
+   public void testConfigurationFromExternalProperties()
+   {
+      Map<String, String> externalProperties = buildExternalProperties(
+            kv(MongoDBConstants.EXTERNAL_CONFIGURATION_PREFIX + MongoDBConstants.SAFE, "false"));
+
+      MongoClientOptions options = buildOptions(null, externalProperties);
+
+      Assert.assertEquals(WriteConcern.NORMAL, options.getWriteConcern());
+
+      externalProperties = buildExternalProperties(
+            kv(MongoDBConstants.EXTERNAL_CONFIGURATION_PREFIX + MongoDBConstants.W, "0"),
+            kv(MongoDBConstants.EXTERNAL_CONFIGURATION_PREFIX + MongoDBConstants.W_TIME_OUT, "1000"),
+            kv(MongoDBConstants.EXTERNAL_CONFIGURATION_PREFIX + MongoDBConstants.FSYNC, "true"),
+            kv(MongoDBConstants.EXTERNAL_CONFIGURATION_PREFIX + MongoDBConstants.J, "false"));
+
+      options = buildOptions(null, externalProperties);
+
+      WriteConcern wc = options.getWriteConcern();
+      Assert.assertEquals(0, wc.getW());
+      Assert.assertEquals(1000, wc.getWtimeout());
+      Assert.assertEquals(true, wc.getFsync());
+      Assert.assertEquals(false, wc.getJ());
+
+      externalProperties = buildExternalProperties(
+            kv(MongoDBConstants.EXTERNAL_CONFIGURATION_PREFIX + MongoDBConstants.DB_DECODER_FACTORY, "com.mongodb.LazyDBDecoder.FACTORY"));
+
+      options = buildOptions(null, externalProperties);
+
+      Assert.assertEquals(LazyDBDecoder.FACTORY, options.getDbDecoderFactory());
+
+      externalProperties = buildExternalProperties(
+            kv(MongoDBConstants.EXTERNAL_CONFIGURATION_PREFIX + MongoDBConstants.DB_DECODER_FACTORY, "com.impetus.kundera.client.mongo.MongoDBConfigurationTest$TestDBDecoderFactory"));
+
+      options = buildOptions(null, externalProperties);
+
+      Assert.assertEquals(TestDBDecoderFactory.class, options.getDbDecoderFactory().getClass());
+
+      externalProperties = buildExternalProperties(
+            kv(MongoDBConstants.EXTERNAL_CONFIGURATION_PREFIX + MongoDBConstants.DB_ENCODER_FACTORY, "com.impetus.kundera.client.mongo.MongoDBConfigurationTest$TestDBEncoderFactory"));
+
+      options = buildOptions(null, externalProperties);
+
+      Assert.assertEquals(TestDBEncoderFactory.class, options.getDbEncoderFactory().getClass());
+
+      externalProperties = buildExternalProperties(
+            kv(MongoDBConstants.EXTERNAL_CONFIGURATION_PREFIX + MongoDBConstants.SOCKET_FACTORY, "com.impetus.kundera.client.mongo.MongoDBConfigurationTest.INSECURE_SSL_SOCKET_FACTORY"));
+
+      options = buildOptions(null, externalProperties);
+
+      Assert.assertEquals(INSECURE_SSL_SOCKET_FACTORY, options.getSocketFactory());
+
+      externalProperties = buildExternalProperties(
+            kv(MongoDBConstants.EXTERNAL_CONFIGURATION_PREFIX + MongoDBConstants.SOCKET_FACTORY, "javax.net.ssl.SSLSocketFactory.getDefault()"));
+
+      options = buildOptions(null, externalProperties);
+
+      Assert.assertEquals(SSLSocketFactory.getDefault().getClass(), options.getSocketFactory().getClass());
+
+      externalProperties = buildExternalProperties(
+            kv(MongoDBConstants.EXTERNAL_CONFIGURATION_PREFIX + MongoDBConstants.AUTO_CONNECT_RETRY, "true"));
+
+      options = buildOptions(null, externalProperties);
+
+      Assert.assertTrue(options.isAutoConnectRetry());
+
+      externalProperties = buildExternalProperties(
+            kv(MongoDBConstants.EXTERNAL_CONFIGURATION_PREFIX + MongoDBConstants.MAX_AUTO_CONNECT_RETRY, "12"));
+
+      options = buildOptions(null, externalProperties);
+
+      Assert.assertEquals(12L, options.getMaxAutoConnectRetryTime());
+
+      externalProperties = buildExternalProperties(
+            kv(MongoDBConstants.EXTERNAL_CONFIGURATION_PREFIX + MongoDBConstants.CONNECTION_PER_HOST, "7"));
+
+      options = buildOptions(null, externalProperties);
+
+      Assert.assertEquals(7, options.getConnectionsPerHost());
+
+      externalProperties = buildExternalProperties(
+            kv(MongoDBConstants.EXTERNAL_CONFIGURATION_PREFIX + MongoDBConstants.CONNECT_TIME_OUT, "32"));
+
+      options = buildOptions(null, externalProperties);
+
+      Assert.assertEquals(32, options.getConnectTimeout());
+
+      externalProperties = buildExternalProperties(
+            kv(MongoDBConstants.EXTERNAL_CONFIGURATION_PREFIX + MongoDBConstants.MAX_WAIT_TIME, "41"));
+
+      options = buildOptions(null, externalProperties);
+
+      Assert.assertEquals(41, options.getMaxWaitTime());
+
+      externalProperties = buildExternalProperties(
+            kv(MongoDBConstants.EXTERNAL_CONFIGURATION_PREFIX + MongoDBConstants.TABCM, "3"));
+
+      options = buildOptions(null, externalProperties);
+
+      Assert.assertEquals(3, options.getThreadsAllowedToBlockForConnectionMultiplier());
+   }
+
+   private MongoClientOptions buildOptions(Properties clientProperties, Map<String, ?> externalProperties)
+   {
+      return new MongoDBClientFactory.PopulateMongoOptions(clientProperties, externalProperties).prepareBuilder().build();
+   }
+
+   private static Properties buildProperties(final KeyValue... keyValuePairs)
+   {
+      Properties properties = new Properties();
+      for (KeyValue item : keyValuePairs)
+      {
+         properties.put(item.getKey(), item.getValue());
+      }
+      return properties;
+   }
+
+   private static Map<String, String> buildExternalProperties(final KeyValue... keyValuePairs)
+   {
+      Map<String, String> properties = new HashMap<String, String>();
+      for (KeyValue item : keyValuePairs)
+      {
+         properties.put(item.getKey(), item.getValue());
+      }
+      return properties;
+   }
+
+   private static KeyValue kv(String key, String value)
+   {
+      return new KeyValue(key, value);
+   }
+
+   private static class KeyValue
+   {
+
+      private final String key;
+      private final String value;
+
+      public KeyValue(final String key, final String value)
+      {
+         this.key = key;
+         this.value = value;
+      }
+
+      public String getKey()
+      {
+         return key;
+      }
+
+      public String getValue()
+      {
+         return value;
+      }
+   }
+
+   public static class TestDBDecoderFactory implements DBDecoderFactory
+   {
+
+      @Override
+      public DBDecoder create()
+      {
+         return null; // dummy
+      }
+   }
+
+   public static class TestDBEncoderFactory implements DBEncoderFactory
+   {
+
+      @Override
+      public DBEncoder create()
+      {
+         return null; // dummy
+      }
+   }
+
+   public static final SSLSocketFactory INSECURE_SSL_SOCKET_FACTORY;
+
+   static
+   {
+      try
+      {
+         final SSLContext sslContext = SSLContext.getInstance("TLS");
+         sslContext.init(null, new TrustManager[]
+               {
+               new X509TrustManager()
+               {
+                  public void checkClientTrusted(final X509Certificate[] x509Certificates, final String s) throws CertificateException
+                  {
+                  }
+
+                  public void checkServerTrusted(final X509Certificate[] x509Certificates, final String s) throws CertificateException
+                  {
+                  }
+
+                  public X509Certificate[] getAcceptedIssuers()
+                  {
+                     return new X509Certificate[0];
+                  }
+               }
+         }, new SecureRandom());
+
+         INSECURE_SSL_SOCKET_FACTORY = sslContext.getSocketFactory();
+      }
+      catch (Exception ex)
+      {
+         throw new AssertionError("Unexpected error", ex);
+      }
+   }
+
+}


### PR DESCRIPTION
Hi,

This change fixes the `MongoClientOptions` builder to reuse the same builder instead of creating a new one on each defined property.
The `PopulateMongoOptions` helper can now create instances from properties too, for example it can set an instance of an `SSLSocketFactory` instead of failing with casting the string to socket factory.
It can instantiate a class, read a static field or invoke a no-argument static method to get the instance, see the `MongoDBConfigurationTest` test for examples.

The factory now also accepts settings coming from the external properties with the `kundera.mongodb.` prefix, e.g. `kundera.mongodb.socket.factory` for example.

I've changed the node address list parsing too to accept a comma-separated `host:port` string on the `kundera.nodes` property.
If all nodes are configured like this then the default port doesn't have to be specified with `kundera.port` anymore, otherwise the default port will be set for nodes without an explicit port.
See the `MongoDBAddressConfigurationValidationTest` test for the different configuration values.

Thanks!