### PR TITLE
Use unlimited max results by default (RDBMS & MongoDB)

### DIFF
--- a/src/jpa-engine/core/src/main/java/com/impetus/kundera/PersistenceProperties.java
+++ b/src/jpa-engine/core/src/main/java/com/impetus/kundera/PersistenceProperties.java
@@ -48,6 +48,9 @@ public interface PersistenceProperties
     /** The Constant KUNDERA_FETCH_MAX_DEPTH. */
     public static final String KUNDERA_FETCH_MAX_DEPTH = "kundera.fetch.max.depth";
 
+    /** The Constant KUNDERA_QUERY_DEFAULT_MAX_RESULTS. */
+    public static final String KUNDERA_QUERY_DEFAULT_MAX_RESULTS = "kundera.query.default.max.results";
+
     /** Connection Pooling related constants. */
 
     // Cap on the number of object instances managed by the pool per node.

--- a/src/jpa-engine/core/src/main/java/com/impetus/kundera/client/DefaultMaxResultsProvider.java
+++ b/src/jpa-engine/core/src/main/java/com/impetus/kundera/client/DefaultMaxResultsProvider.java
@@ -1,0 +1,15 @@
+package com.impetus.kundera.client;
+
+/**
+ * Defines a method for clients to override the default maxResults setting for queries.
+ */
+public interface DefaultMaxResultsProvider {
+
+   /**
+    * Returns the default maxResults setting to apply for queries.
+    *
+    * @return the default maxResults setting to apply for queries
+    */
+   int getDefaultMaxResults();
+
+}

--- a/src/kundera-mongo/src/main/java/com/impetus/client/mongodb/MongoDBClient.java
+++ b/src/kundera-mongo/src/main/java/com/impetus/client/mongodb/MongoDBClient.java
@@ -38,6 +38,7 @@ import com.impetus.kundera.PersistenceProperties;
 import com.impetus.kundera.client.Client;
 import com.impetus.kundera.client.ClientBase;
 import com.impetus.kundera.client.ClientPropertiesSetter;
+import com.impetus.kundera.client.DefaultMaxResultsProvider;
 import com.impetus.kundera.client.EnhanceEntity;
 import com.impetus.kundera.db.RelationHolder;
 import com.impetus.kundera.generator.Generator;
@@ -83,7 +84,7 @@ import com.mongodb.util.JSONParseException;
  * 
  * @author devender.yadav
  */
-public class MongoDBClient extends ClientBase implements Client<MongoDBQuery>, Batcher, ClientPropertiesSetter
+public class MongoDBClient extends ClientBase implements Client<MongoDBQuery>, Batcher, ClientPropertiesSetter, DefaultMaxResultsProvider
 
 {
     /** The mongo db. */
@@ -1282,6 +1283,12 @@ public class MongoDBClient extends ClientBase implements Client<MongoDBQuery>, B
     public void populateClientProperties(Client client, Map<String, Object> properties)
     {
         new MongoDBClientProperties().populateClientProperties(client, properties);
+    }
+
+    @Override
+    public int getDefaultMaxResults()
+    {
+        return 0; // allow returning unlimited number of results unless otherwise specified
     }
 
     /**

--- a/src/kundera-mongo/src/main/java/com/impetus/client/mongodb/query/MongoDBQuery.java
+++ b/src/kundera-mongo/src/main/java/com/impetus/client/mongodb/query/MongoDBQuery.java
@@ -872,9 +872,24 @@ public class MongoDBQuery extends QueryImpl
     {
         EntityMetadata m = getEntityMetadata();
         Client client = persistenceDelegeator.getClient(m);
+
+        int fetchSize;
+        if (getFetchSize() != null)
+        {
+            fetchSize = getFetchSize();
+        }
+        else if (this.maxResult != 0)
+        {
+            fetchSize = this.maxResult;
+        }
+        else
+        {
+            fetchSize = Integer.MAX_VALUE;
+        }
+
         return new ResultIterator((MongoDBClient) client, m, createMongoQuery(m, getKunderaQuery()
                 .getFilterClauseQueue()), getOrderByClause(m), getKeys(m, getKunderaQuery().getResult()),
-                persistenceDelegeator, getFetchSize() != null ? getFetchSize() : this.maxResult);
+                persistenceDelegeator, fetchSize);
     }
 
     /**

--- a/src/kundera-mongo/src/test/java/com/impetus/kundera/client/mongo/MongoQueryDefaultsTest.java
+++ b/src/kundera-mongo/src/test/java/com/impetus/kundera/client/mongo/MongoQueryDefaultsTest.java
@@ -1,0 +1,146 @@
+package com.impetus.kundera.client.mongo;
+
+import com.impetus.kundera.PersistenceProperties;
+import junit.framework.Assert;
+import org.junit.Test;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Persistence;
+import javax.persistence.Query;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Testing the options for defining the default maxResults setting for queries.
+ */
+public class MongoQueryDefaultsTest
+{
+
+   /** The emf. */
+   private static EntityManagerFactory emf;
+
+   /** The em. */
+   private static EntityManager em;
+
+   @Test
+   public void testDefaultMaxResultsIsApplied()
+   {
+      emf = Persistence.createEntityManagerFactory("mongoTest");
+      em = emf.createEntityManager();
+
+      try
+      {
+         Query query = em.createQuery("select p from PersonMongo p");
+         Assert.assertEquals(0, query.getMaxResults());
+      }
+      finally
+      {
+         em.close();
+         emf.close();
+      }
+   }
+
+   @Test
+   public void testMaxResultsOverrideFromExternalProperties()
+   {
+      Map<String, Object> properties = new HashMap<String, Object>();
+      properties.put(PersistenceProperties.KUNDERA_QUERY_DEFAULT_MAX_RESULTS, "32");
+
+      emf = Persistence.createEntityManagerFactory("mongoTest", properties);
+      em = emf.createEntityManager();
+
+      try
+      {
+         Query query = em.createQuery("select p from PersonMongo p");
+         Assert.assertEquals(32, query.getMaxResults());
+      }
+      finally
+      {
+         em.close();
+         emf.close();
+      }
+   }
+
+   @Test
+   public void testMaxResultsOverrideFromPersistenceProperties()
+   {
+      emf = Persistence.createEntityManagerFactory("MongoDefaultsTest");
+      em = emf.createEntityManager();
+
+      try
+      {
+         Query query = em.createQuery("select u from UserInformation u");
+         Assert.assertEquals(47, query.getMaxResults());
+      }
+      finally
+      {
+         em.close();
+         emf.close();
+      }
+   }
+
+   @Test
+   public void testExternalPropertiesOverrideTakesPrecedence()
+   {
+      Map<String, Object> properties = new HashMap<String, Object>();
+      properties.put(PersistenceProperties.KUNDERA_QUERY_DEFAULT_MAX_RESULTS, "91");
+
+      emf = Persistence.createEntityManagerFactory("MongoDefaultsTest", properties);
+      em = emf.createEntityManager();
+
+      try
+      {
+         Query query = em.createQuery("select u from UserInformation u");
+         Assert.assertEquals(91, query.getMaxResults());
+      }
+      finally
+      {
+         em.close();
+         emf.close();
+      }
+   }
+
+   @Test
+   public void testNativeQuery()
+   {
+      Map<String, Object> properties = new HashMap<String, Object>();
+      properties.put(PersistenceProperties.KUNDERA_QUERY_DEFAULT_MAX_RESULTS, "52");
+
+      emf = Persistence.createEntityManagerFactory("mongoTest", properties);
+      em = emf.createEntityManager();
+
+      try
+      {
+         Query query = em.createNativeQuery("db.PERSON.find({})");
+         Assert.assertEquals(52, query.getMaxResults());
+      }
+      finally
+      {
+         em.close();
+         emf.close();
+      }
+   }
+
+   @Test
+   public void testNamedQuery()
+   {
+      Map<String, Object> properties = new HashMap<String, Object>();
+      properties.put(PersistenceProperties.KUNDERA_QUERY_DEFAULT_MAX_RESULTS, "77");
+
+      emf = Persistence.createEntityManagerFactory("mongoTest", properties);
+      em = emf.createEntityManager();
+
+      try
+      {
+         Query query = em.createNamedQuery("mongo.named.query");
+         Assert.assertEquals(77, query.getMaxResults());
+      }
+      finally
+      {
+         em.close();
+         emf.close();
+      }
+   }
+
+}

--- a/src/kundera-mongo/src/test/resources/META-INF/persistence.xml
+++ b/src/kundera-mongo/src/test/resources/META-INF/persistence.xml
@@ -196,4 +196,17 @@
 		</properties>
 	</persistence-unit>
 
+	<persistence-unit name="MongoDefaultsTest">
+		<provider>com.impetus.kundera.KunderaPersistence</provider>
+		<properties>
+			<property name="kundera.nodes" value="localhost" />
+			<property name="kundera.port" value="27017" />
+			<property name="kundera.keyspace" value="KunderaExamples" />
+			<property name="kundera.dialect" value="mongodb" />
+			<property name="kundera.client.lookup.class"
+				value="com.impetus.client.mongodb.MongoDBClientFactory" />
+			<property name="kundera.query.default.max.results" value="47" />
+		</properties>
+	</persistence-unit>
+
 </persistence>

--- a/src/kundera-rdbms/src/main/java/com/impetus/client/rdbms/HibernateClient.java
+++ b/src/kundera-rdbms/src/main/java/com/impetus/client/rdbms/HibernateClient.java
@@ -52,6 +52,7 @@ import com.impetus.client.rdbms.query.RDBMSQuery;
 import com.impetus.kundera.KunderaException;
 import com.impetus.kundera.client.Client;
 import com.impetus.kundera.client.ClientBase;
+import com.impetus.kundera.client.DefaultMaxResultsProvider;
 import com.impetus.kundera.client.EnhanceEntity;
 import com.impetus.kundera.db.RelationHolder;
 import com.impetus.kundera.generator.Generator;
@@ -80,7 +81,7 @@ import com.impetus.kundera.utils.KunderaCoreUtils;
  * 
  * @author vivek.mishra
  */
-public class HibernateClient extends ClientBase implements Client<RDBMSQuery>
+public class HibernateClient extends ClientBase implements Client<RDBMSQuery>, DefaultMaxResultsProvider
 {
 
     /** The client factory. */
@@ -752,6 +753,12 @@ public class HibernateClient extends ClientBase implements Client<RDBMSQuery>
     public Class<RDBMSQuery> getQueryImplementor()
     {
         return RDBMSQuery.class;
+    }
+
+    @Override
+    public int getDefaultMaxResults()
+    {
+        return 0; // allow returning unlimited number of results unless otherwise specified
     }
 
     /**

--- a/src/kundera-rdbms/src/main/java/com/impetus/client/rdbms/query/RDBMSQuery.java
+++ b/src/kundera-rdbms/src/main/java/com/impetus/client/rdbms/query/RDBMSQuery.java
@@ -198,11 +198,24 @@ public class RDBMSQuery extends QueryImpl
             throw new UnsupportedOperationException("Iteration not supported over native queries");
         }
 
+        int fetchSize;
+        if (getFetchSize() != null)
+        {
+            fetchSize = getFetchSize();
+        }
+        else if (this.maxResult != 0)
+        {
+            fetchSize = this.maxResult;
+        }
+        else
+        {
+            fetchSize = Integer.MAX_VALUE;
+        }
+
         initializeReader();
         EntityMetadata m = getEntityMetadata();
         Client client = persistenceDelegeator.getClient(m);
-        return new ResultIterator((HibernateClient) client, m, persistenceDelegeator,
-                getFetchSize() != null ? getFetchSize() : this.maxResult,
+        return new ResultIterator((HibernateClient) client, m, persistenceDelegeator, fetchSize,
                 ((RDBMSEntityReader) getReader()).getSqlQueryFromJPA(m, m.getRelationNames(), null));
     }
 

--- a/src/kundera-rdbms/src/test/java/com/impetus/kundera/client/RDBMSQueryDefaultsTest.java
+++ b/src/kundera-rdbms/src/test/java/com/impetus/kundera/client/RDBMSQueryDefaultsTest.java
@@ -1,0 +1,123 @@
+package com.impetus.kundera.client;
+
+import com.impetus.kundera.PersistenceProperties;
+import junit.framework.Assert;
+import org.junit.Test;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Persistence;
+import javax.persistence.Query;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Testing the options for defining the default maxResults setting for queries.
+ */
+public class RDBMSQueryDefaultsTest
+{
+
+   private EntityManagerFactory emf;
+
+   private EntityManager em;
+
+   @Test
+   public void testDefaultMaxResultsIsApplied()
+   {
+      emf = Persistence.createEntityManagerFactory("testHibernate");
+      em = emf.createEntityManager();
+
+      try
+      {
+         Query query = em.createQuery("select p from PersonRDBMS p");
+         Assert.assertEquals(0, query.getMaxResults());
+      }
+      finally
+      {
+         em.close();
+         emf.close();
+      }
+   }
+
+   @Test
+   public void testMaxResultsOverrideFromExternalProperties()
+   {
+      Map<String, Object> properties = new HashMap<String, Object>();
+      properties.put(PersistenceProperties.KUNDERA_QUERY_DEFAULT_MAX_RESULTS, "32");
+
+      emf = Persistence.createEntityManagerFactory("testHibernate", properties);
+      em = emf.createEntityManager();
+
+      try
+      {
+         Query query = em.createQuery("select p from PersonRDBMS p");
+         Assert.assertEquals(32, query.getMaxResults());
+      }
+      finally
+      {
+         em.close();
+         emf.close();
+      }
+   }
+
+   @Test
+   public void testMaxResultsOverrideFromPersistenceProperties()
+   {
+      emf = Persistence.createEntityManagerFactory("RdbmsDefaultsTest");
+      em = emf.createEntityManager();
+
+      try
+      {
+         Query query = em.createQuery("select u from PersonRDBMS u");
+         Assert.assertEquals(47, query.getMaxResults());
+      }
+      finally
+      {
+         em.close();
+         emf.close();
+      }
+   }
+
+   @Test
+   public void testExternalPropertiesOverrideTakesPrecedence()
+   {
+      Map<String, Object> properties = new HashMap<String, Object>();
+      properties.put(PersistenceProperties.KUNDERA_QUERY_DEFAULT_MAX_RESULTS, "91");
+
+      emf = Persistence.createEntityManagerFactory("RdbmsDefaultsTest", properties);
+      em = emf.createEntityManager();
+
+      try
+      {
+         Query query = em.createQuery("select p from PersonRDBMS p");
+         Assert.assertEquals(91, query.getMaxResults());
+      }
+      finally
+      {
+         em.close();
+         emf.close();
+      }
+   }
+
+   @Test
+   public void testNativeQuery()
+   {
+      Map<String, Object> properties = new HashMap<String, Object>();
+      properties.put(PersistenceProperties.KUNDERA_QUERY_DEFAULT_MAX_RESULTS, "52");
+
+      emf = Persistence.createEntityManagerFactory("RdbmsDefaultsTest", properties);
+      em = emf.createEntityManager();
+
+      try
+      {
+         Query query = em.createNativeQuery("select * FROM testdb.PERSON");
+         Assert.assertEquals(52, query.getMaxResults());
+      }
+      finally
+      {
+         em.close();
+         emf.close();
+      }
+   }
+
+}

--- a/src/kundera-rdbms/src/test/resources/META-INF/persistence.xml
+++ b/src/kundera-rdbms/src/test/resources/META-INF/persistence.xml
@@ -117,4 +117,15 @@
 		</properties>
 	</persistence-unit>
 
+	<persistence-unit name="RdbmsDefaultsTest">
+		<provider>com.impetus.kundera.KunderaPersistence</provider>
+		<class>com.impetus.client.crud.entities.PersonRDBMS</class>
+		<exclude-unlisted-classes>true</exclude-unlisted-classes>
+		<properties>
+			<property name="kundera.client.lookup.class" value="com.impetus.client.rdbms.RDBMSClientFactory" />
+			<property name="kundera.client.property" value="hibernate.properties" />
+			<property name="kundera.query.default.max.results" value="47" />
+		</properties>
+	</persistence-unit>
+
 </persistence>


### PR DESCRIPTION
Hi,

This change is to allow unlimited results by default for RDBMS and MongoDB.

Please note that the `MongoESAggregationTest` and the `MongoESOrderByTest` started failing for me though I'm not exactly sure if it's because of this change.
Can you please test it with a working ES setup?

Thanks!