### PR TITLE
Revert "Default max results for Mongo and RDBMS"

### DIFF
--- a/src/kundera-elastic-search/src/main/java/com/impetus/client/es/index/ESIndexer.java
+++ b/src/kundera-elastic-search/src/main/java/com/impetus/client/es/index/ESIndexer.java
@@ -280,7 +280,7 @@ public class ESIndexer implements Indexer
         {
             builder.setQuery(queryBuilder);
             builder.setFrom(firstResult);
-            builder.setSize(maxResults == 0 ? -1 : maxResults);
+            builder.setSize(maxResults);
             addSortOrder(builder, kunderaQuery, m, kunderaMetadata);
         }
         else

--- a/src/kundera-mongo/src/main/java/com/impetus/client/mongodb/query/MongoDBQuery.java
+++ b/src/kundera-mongo/src/main/java/com/impetus/client/mongodb/query/MongoDBQuery.java
@@ -92,7 +92,6 @@ public class MongoDBQuery extends QueryImpl
             final KunderaMetadata kunderaMetadata)
     {
         super(kunderaQuery, persistenceDelegator, kunderaMetadata);
-        setMaxResults(0);
     }
 
     /*
@@ -873,24 +872,9 @@ public class MongoDBQuery extends QueryImpl
     {
         EntityMetadata m = getEntityMetadata();
         Client client = persistenceDelegeator.getClient(m);
-
-        int fetchSize;
-        if (getFetchSize() != null)
-        {
-            fetchSize = getFetchSize();
-        }
-        else if (this.maxResult != 0)
-        {
-            fetchSize = this.maxResult;
-        }
-        else
-        {
-            fetchSize = Integer.MAX_VALUE;
-        }
-
         return new ResultIterator((MongoDBClient) client, m, createMongoQuery(m, getKunderaQuery()
                 .getFilterClauseQueue()), getOrderByClause(m), getKeys(m, getKunderaQuery().getResult()),
-                persistenceDelegeator, fetchSize);
+                persistenceDelegeator, getFetchSize() != null ? getFetchSize() : this.maxResult);
     }
 
     /**

--- a/src/kundera-rdbms/src/main/java/com/impetus/client/rdbms/query/RDBMSQuery.java
+++ b/src/kundera-rdbms/src/main/java/com/impetus/client/rdbms/query/RDBMSQuery.java
@@ -75,7 +75,6 @@ public class RDBMSQuery extends QueryImpl
             final KunderaMetadata kunderaMetadata)
     {
         super(kunderaQuery, persistenceDelegator, kunderaMetadata);
-        setMaxResults(0);
     }
 
     @Override
@@ -202,22 +201,8 @@ public class RDBMSQuery extends QueryImpl
         initializeReader();
         EntityMetadata m = getEntityMetadata();
         Client client = persistenceDelegeator.getClient(m);
-
-        int fetchSize;
-        if (getFetchSize() != null)
-        {
-            fetchSize = getFetchSize();
-        }
-        else if (this.maxResult != 0)
-        {
-            fetchSize = this.maxResult;
-        }
-        else
-        {
-            fetchSize = Integer.MAX_VALUE;
-        }
-
-        return new ResultIterator((HibernateClient) client, m, persistenceDelegeator, fetchSize,
+        return new ResultIterator((HibernateClient) client, m, persistenceDelegeator,
+                getFetchSize() != null ? getFetchSize() : this.maxResult,
                 ((RDBMSEntityReader) getReader()).getSqlQueryFromJPA(m, m.getRelationNames(), null));
     }
 


### PR DESCRIPTION
Reverts impetus-opensource/Kundera#922

`MongoESOrderByTest` and `MongoESAggregationTest` are failing for this PR. Please look into this. We will review and merge it once the build is smooth. 

Let us know if you are facing any issue with this.

-Dev