### PR TITLE
Support replica sets on Mongo

### DIFF
--- a/src/kundera-mongo/src/main/java/com/impetus/client/mongodb/MongoDBClientFactory.java
+++ b/src/kundera-mongo/src/main/java/com/impetus/client/mongodb/MongoDBClientFactory.java
@@ -489,6 +489,10 @@ public class MongoDBClientFactory extends GenericClientFactory
                 {
                     builder.threadsAllowedToBlockForConnectionMultiplier(getProperty(MongoDBConstants.TABCM, int.class));
                 }
+                if (hasProperty(MongoDBConstants.REPLICA_SET_NAME))
+                {
+                    builder.requiredReplicaSetName(getProperty(MongoDBConstants.REPLICA_SET_NAME, String.class));
+                }
             }
             catch (NumberFormatException nfe)
             {

--- a/src/kundera-mongo/src/main/java/com/impetus/client/mongodb/MongoDBConstants.java
+++ b/src/kundera-mongo/src/main/java/com/impetus/client/mongodb/MongoDBConstants.java
@@ -95,4 +95,7 @@ public interface MongoDBConstants
 
     /** The Constant ORDERED_BULK_OPERATION. */
     public final static String ORDERED_BULK_OPERATION = "ordered.bulk.operation";
+
+    /** The Constant REPLICA_SET_NAME. */
+    public final static String REPLICA_SET_NAME = "replica.set.name";
 }


### PR DESCRIPTION
Hi,

This change allows configuring the Mongo driver to treat the target cluster as a replica set with the name given in the `replica.set.name` property.