### PR TITLE
Fix number of lgtm.com alerts: reference equality and suspicious logic

### DIFF
--- a/src/jpa-engine/core/src/main/java/com/impetus/kundera/query/KunderaQueryParser.java
+++ b/src/jpa-engine/core/src/main/java/com/impetus/kundera/query/KunderaQueryParser.java
@@ -375,7 +375,7 @@ public class KunderaQueryParser
             }
 
             // content cannot be empty
-            if (groupByClause == null && groupByClause.toActualText().length() == 0)
+            if (groupByClause == null || groupByClause.toActualText().length() == 0)
             {
                 throw new JPQLParseException("keyword without value: GROUP BY");
             }
@@ -396,7 +396,7 @@ public class KunderaQueryParser
             }
 
             // content cannot be empty
-            if (havingClause == null && havingClause.toActualText().length() == 0)
+            if (havingClause == null || havingClause.toActualText().length() == 0)
             {
                 throw new JPQLParseException("keyword without value: HAVING");
             }

--- a/src/jpa-engine/core/src/main/java/com/impetus/kundera/utils/NumericUtils.java
+++ b/src/jpa-engine/core/src/main/java/com/impetus/kundera/utils/NumericUtils.java
@@ -84,15 +84,17 @@ public final class NumericUtils
                 break;
 
             case BIGDECIMAL:
-                returnValue = new BigDecimal(value) == (BigDecimal.ZERO);
+                // Note: cannot use 'equals' here - it would require both BigDecimals to have
+                // the same scale.
+                returnValue = (new BigDecimal(value)).compareTo(BigDecimal.ZERO) == 0;
                 break;
 
             case BIGINTEGER:
-                returnValue = new BigInteger(value) == (BigInteger.ZERO);
+                returnValue = (new BigInteger(value)).equals(BigInteger.ZERO);
                 break;
             
             case SHORT:
-                returnValue = new Short(value) == (NumberUtils.SHORT_ZERO);
+                returnValue = (new Short(value)).shortValue() == NumberUtils.SHORT_ZERO.shortValue();
                 break;
             }
         }


### PR DESCRIPTION
This PR addresses a number of alerts from lgtm.com (@lgtmhq):

```KunderaQueryParser.java```: ```groupByClause``` and ```havingClause``` are guaranteed to be null. Likely logic error. More details: https://lgtm.com/projects/g/impetus-opensource/Kundera/snapshot/6cb44eecc2fb281e54345324b95e801bb55225e6/files/src/jpa-engine/core/src/main/java/com/impetus/kundera/query/KunderaQueryParser.java#V378

```NumericUtils.java```: three reference equality tests which will not test value equality for BigInteger, BigDecimal, and Short (boxed). More details: https://lgtm.com/projects/g/impetus-opensource/Kundera/snapshot/6cb44eecc2fb281e54345324b95e801bb55225e6/files/src/jpa-engine/core/src/main/java/com/impetus/kundera/utils/NumericUtils.java#V95

There are about 50 more alerts on lgtm.com: https://lgtm.com/projects/g/impetus-opensource/Kundera/alerts. I'm not familiar enough with the Kundera code base to judge (and possibly fix) them all, but they're certainly worth a look!