### PR TITLE
Add bind parameters support for cassandra native queries

### DIFF
--- a/src/jpa-engine/core/src/main/java/com/impetus/kundera/query/KunderaQuery.java
+++ b/src/jpa-engine/core/src/main/java/com/impetus/kundera/query/KunderaQuery.java
@@ -119,6 +119,9 @@ public class KunderaQuery
     /** The parameters map. */
     private Map<String, Object> parametersMap = new HashMap<String, Object>();
 
+    /** Bind parameters */
+    private final List<BindParameter> bindParameters = new ArrayList<>();
+
     /** The is native query. */
     boolean isNativeQuery;
 
@@ -475,6 +478,18 @@ public class KunderaQuery
     {
         return parametersMap;
     }
+
+
+   /**
+     * Gets the bind parameters map.
+     * 
+     * @return Map of query parameters.
+     */
+    public List<BindParameter> getBindParameters()
+    {
+        return bindParameters;
+    }
+
 
     /**
      * Method to check if required result is to get complete entity or a select
@@ -911,9 +926,15 @@ public class KunderaQuery
      * @param value
      *            the value
      */
+
     public final void setParameter(String name, Object value)
     {
-        setParameterValue(":" + name, value);
+        if (isNative()) {
+            bindParameters.add(new BindParameter(name, value));
+	} else {
+            setParameterValue(":" + name, value);
+	}
+
         parametersMap.put(":" + name, value);
     }
 
@@ -927,7 +948,12 @@ public class KunderaQuery
      */
     public final void setParameter(int position, Object value)
     {
-        setParameterValue("?" + position, value);
+	if (isNative()) {
+	    bindParameters.add(new BindParameter(position, value));
+	} else {
+            setParameterValue("?" + position, value);
+	}
+
         parametersMap.put("?" + position, value);
     }
 
@@ -1803,5 +1829,53 @@ public class KunderaQuery
 
         return value;
     }
+
+
+
+    /*
+     * XXX
+     * Indexed or named bind parameter for queries
+     */
+
+    public static class BindParameter implements java.io.Serializable {
+
+	    public BindParameter(final String name, final Object value) {
+		    this.name = name;
+		    this.index = -1;
+		    this.value = value;
+	    }
+
+	    public BindParameter(final int index, final Object value) {
+		    this.name = null;
+		    this.index = index;
+		    this.value = value;
+	    }
+
+
+	    private final String name;
+
+	    public String getName() {
+		    return name;
+	    }
+
+	    public boolean isNamed() {
+		    return (getName() != null);
+	    }
+
+
+	    private final int index;
+
+	    public int getIndex() {
+		    return index;
+	    }
+
+
+	    private final Object value;
+
+	    public Object getValue() {
+		    return value;
+	    }
+    }
+
 
 }

--- a/src/jpa-engine/core/src/main/java/com/impetus/kundera/query/KunderaQuery.java
+++ b/src/jpa-engine/core/src/main/java/com/impetus/kundera/query/KunderaQuery.java
@@ -54,11 +54,10 @@ import com.impetus.kundera.persistence.EntityManagerFactoryImpl.KunderaMetadata;
 /**
  * The Class KunderaQuery.
  */
-public class KunderaQuery
-{
+public class KunderaQuery {
     /** The Constant SINGLE_STRING_KEYWORDS. */
-    public static final String[] SINGLE_STRING_KEYWORDS = { "SELECT", "UPDATE", "SET", "DELETE", "UNIQUE", "FROM",
-            "WHERE", "GROUP BY", "HAVING", "ORDER BY" };
+    public static final String[] SINGLE_STRING_KEYWORDS =
+        { "SELECT", "UPDATE", "SET", "DELETE", "UNIQUE", "FROM", "WHERE", "GROUP BY", "HAVING", "ORDER BY" };
 
     /** The Constant INTER_CLAUSE_OPERATORS. */
     public static final String[] INTER_CLAUSE_OPERATORS = { "AND", "OR", "BETWEEN", "(", ")" };
@@ -152,8 +151,7 @@ public class KunderaQuery
      * @param expressionFactory
      *            the expressionFactory to set
      */
-    public void setExpressionFactory(ExpressionFactory expressionFactory)
-    {
+    public void setExpressionFactory(ExpressionFactory expressionFactory) {
         this.expressionFactory = expressionFactory;
     }
 
@@ -162,8 +160,7 @@ public class KunderaQuery
      * 
      * @return the jpqlExpression
      */
-    public JPQLExpression getJpqlExpression()
-    {
+    public JPQLExpression getJpqlExpression() {
         return jpqlExpression;
     }
 
@@ -175,8 +172,7 @@ public class KunderaQuery
      * @param kunderaMetadata
      *            the kundera metadata
      */
-    public KunderaQuery(final String jpaQuery, final KunderaMetadata kunderaMetadata)
-    {
+    public KunderaQuery(final String jpaQuery, final KunderaMetadata kunderaMetadata) {
         this.jpaQuery = jpaQuery;
         this.kunderaMetadata = kunderaMetadata;
         initiateJPQLObject(jpaQuery);
@@ -188,8 +184,7 @@ public class KunderaQuery
      * @param jpaQuery
      *            the jpa query
      */
-    private void initiateJPQLObject(final String jpaQuery)
-    {
+    private void initiateJPQLObject(final String jpaQuery) {
         JPQLGrammar jpqlGrammar = EclipseLinkJPQLGrammar2_4.instance();
         this.jpqlExpression = new JPQLExpression(jpaQuery, jpqlGrammar, "ql_statement", true);
         setKunderaQueryTypeObject();
@@ -198,31 +193,22 @@ public class KunderaQuery
     /**
      * Sets the kundera query type object.
      */
-    private void setKunderaQueryTypeObject()
-    {
+    private void setKunderaQueryTypeObject() {
 
-        try
-        {
-            if (isSelectStatement())
-            {
+        try {
+            if (isSelectStatement()) {
 
                 this.setSelectStatement((SelectStatement) (this.getJpqlExpression().getQueryStatement()));
 
-            }
-            else if (isUpdateStatement())
-            {
+            } else if (isUpdateStatement()) {
 
                 this.setUpdateStatement((UpdateStatement) (this.getJpqlExpression().getQueryStatement()));
 
-            }
-            else if (isDeleteStatement())
-            {
+            } else if (isDeleteStatement()) {
                 this.setDeleteStatement((DeleteStatement) (this.getJpqlExpression().getQueryStatement()));
 
             }
-        }
-        catch (ClassCastException cce)
-        {
+        } catch (ClassCastException cce) {
             throw new JPQLParseException("Bad query format : " + cce.getMessage());
         }
 
@@ -233,8 +219,7 @@ public class KunderaQuery
      * 
      * @return the selectStatement
      */
-    public SelectStatement getSelectStatement()
-    {
+    public SelectStatement getSelectStatement() {
         return selectStatement;
     }
 
@@ -244,8 +229,7 @@ public class KunderaQuery
      * @param selectStatement
      *            the selectStatement to set
      */
-    public void setSelectStatement(SelectStatement selectStatement)
-    {
+    public void setSelectStatement(SelectStatement selectStatement) {
         this.selectStatement = selectStatement;
     }
 
@@ -255,8 +239,7 @@ public class KunderaQuery
      * @param updateStatement
      *            the updateStatement to set
      */
-    public void setUpdateStatement(UpdateStatement updateStatement)
-    {
+    public void setUpdateStatement(UpdateStatement updateStatement) {
         this.updateStatement = updateStatement;
     }
 
@@ -265,8 +248,7 @@ public class KunderaQuery
      * 
      * @return the updateStatement
      */
-    public UpdateStatement getUpdateStatement()
-    {
+    public UpdateStatement getUpdateStatement() {
         return updateStatement;
     }
 
@@ -275,8 +257,7 @@ public class KunderaQuery
      * 
      * @return the deleteStatement
      */
-    public DeleteStatement getDeleteStatement()
-    {
+    public DeleteStatement getDeleteStatement() {
         return deleteStatement;
     }
 
@@ -286,8 +267,7 @@ public class KunderaQuery
      * @param deleteStatement
      *            the deleteStatement to set
      */
-    public void setDeleteStatement(DeleteStatement deleteStatement)
-    {
+    public void setDeleteStatement(DeleteStatement deleteStatement) {
         this.deleteStatement = deleteStatement;
     }
 
@@ -296,8 +276,7 @@ public class KunderaQuery
      * 
      * @return true, if is select statement
      */
-    public boolean isSelectStatement()
-    {
+    public boolean isSelectStatement() {
         return this.getJpqlExpression().getQueryStatement().getClass().isAssignableFrom(SelectStatement.class);
 
     }
@@ -307,8 +286,7 @@ public class KunderaQuery
      * 
      * @return true, if is delete statement
      */
-    public boolean isDeleteStatement()
-    {
+    public boolean isDeleteStatement() {
         return this.getJpqlExpression().getQueryStatement().getClass().isAssignableFrom(DeleteStatement.class);
     }
 
@@ -317,8 +295,7 @@ public class KunderaQuery
      * 
      * @return true, if is update statement
      */
-    public boolean isUpdateStatement()
-    {
+    public boolean isUpdateStatement() {
         return this.getJpqlExpression().getQueryStatement().getClass().isAssignableFrom(UpdateStatement.class);
     }
 
@@ -327,8 +304,7 @@ public class KunderaQuery
      * 
      * @return the expressionFactory
      */
-    public ExpressionFactory getExpressionFactory()
-    {
+    public ExpressionFactory getExpressionFactory() {
         return expressionFactory;
     }
 
@@ -338,8 +314,7 @@ public class KunderaQuery
      * @param groupingClause
      *            the new grouping
      */
-    public void setGrouping(String groupingClause)
-    {
+    public void setGrouping(String groupingClause) {
     }
 
     /**
@@ -348,8 +323,7 @@ public class KunderaQuery
      * @param result
      *            the new result
      */
-    public final void setResult(String[] result)
-    {
+    public final void setResult(String[] result) {
         this.result = result;
     }
 
@@ -359,8 +333,7 @@ public class KunderaQuery
      * @param aggResult
      *            the new result
      */
-    public final void setAggregationResult(String[] aggResult)
-    {
+    public final void setAggregationResult(String[] aggResult) {
         this.aggregationResult = aggResult;
     }
 
@@ -369,8 +342,7 @@ public class KunderaQuery
      * 
      * @return Aggregation result set
      */
-    public final String[] getAggResult()
-    {
+    public final String[] getAggResult() {
         return aggregationResult;
     }
 
@@ -379,8 +351,7 @@ public class KunderaQuery
      * 
      * @return Query contains aggregation or not
      */
-    public boolean isAggregated()
-    {
+    public boolean isAggregated() {
         return isAggregate;
     }
 
@@ -390,8 +361,7 @@ public class KunderaQuery
      * @param isAggregated
      *            the new aggregated
      */
-    public void setAggregated(boolean isAggregated)
-    {
+    public void setAggregated(boolean isAggregated) {
         this.isAggregate = isAggregated;
     }
 
@@ -401,8 +371,7 @@ public class KunderaQuery
      * @param from
      *            the new from
      */
-    public final void setFrom(String from)
-    {
+    public final void setFrom(String from) {
         this.from = from;
     }
 
@@ -412,8 +381,7 @@ public class KunderaQuery
      * @param filter
      *            the new filter
      */
-    public final void setFilter(String filter)
-    {
+    public final void setFilter(String filter) {
         this.filter = filter;
     }
 
@@ -423,8 +391,7 @@ public class KunderaQuery
      * @param ordering
      *            the new ordering
      */
-    public final void setOrdering(String ordering)
-    {
+    public final void setOrdering(String ordering) {
         this.ordering = ordering;
         parseOrdering(this.ordering);
     }
@@ -434,8 +401,7 @@ public class KunderaQuery
      * 
      * @return the filter
      */
-    public final String getFilter()
-    {
+    public final String getFilter() {
         return filter;
     }
 
@@ -444,8 +410,7 @@ public class KunderaQuery
      * 
      * @return the from
      */
-    public final String getFrom()
-    {
+    public final String getFrom() {
         return from;
     }
 
@@ -454,8 +419,7 @@ public class KunderaQuery
      * 
      * @return the ordering
      */
-    public final List<SortOrdering> getOrdering()
-    {
+    public final List<SortOrdering> getOrdering() {
         return sortOrders;
     }
 
@@ -464,8 +428,7 @@ public class KunderaQuery
      * 
      * @return the result
      */
-    public final String[] getResult()
-    {
+    public final String[] getResult() {
         return result;
     }
 
@@ -474,32 +437,26 @@ public class KunderaQuery
      * 
      * @return Map of query parameters.
      */
-    public Map<String, Object> getParametersMap()
-    {
+    public Map<String, Object> getParametersMap() {
         return parametersMap;
     }
 
-
-   /**
+    /**
      * Gets the bind parameters map.
      * 
      * @return Map of query parameters.
      */
-    public List<BindParameter> getBindParameters()
-    {
+    public List<BindParameter> getBindParameters() {
         return bindParameters;
     }
 
-
     /**
-     * Method to check if required result is to get complete entity or a select
-     * scalar value.
+     * Method to check if required result is to get complete entity or a select scalar value.
      * 
      * @return true, if it result is for complete alias.
      * 
      */
-    public final boolean isAliasOnly()
-    {
+    public final boolean isAliasOnly() {
         // TODO
         return result != null && (result[0].indexOf(".") == -1);
     }
@@ -509,8 +466,7 @@ public class KunderaQuery
      * 
      * @return jpaParameters
      */
-    public Set<Parameter<?>> getParameters()
-    {
+    public Set<Parameter<?>> getParameters() {
         return typedParameter != null ? typedParameter.jpaParameters : null;
     }
 
@@ -521,8 +477,7 @@ public class KunderaQuery
      *            the param
      * @return true, if is bound
      */
-    public boolean isBound(Parameter param)
-    {
+    public boolean isBound(Parameter param) {
         return getClauseValue(param) != null;
     }
 
@@ -533,17 +488,12 @@ public class KunderaQuery
      *            the param string
      * @return the clause value
      */
-    public List<Object> getClauseValue(String paramString)
-    {
-        if (typedParameter != null && typedParameter.getParameters() != null)
-        {
+    public List<Object> getClauseValue(String paramString) {
+        if (typedParameter != null && typedParameter.getParameters() != null) {
             List<FilterClause> clauses = typedParameter.getParameters().get(paramString);
-            if (clauses != null)
-            {
+            if (clauses != null) {
                 return clauses.get(0).getValue();
-            }
-            else
-            {
+            } else {
                 throw new IllegalArgumentException("parameter is not a parameter of the query");
             }
         }
@@ -560,36 +510,24 @@ public class KunderaQuery
      * 
      * @return clause value.
      */
-    public List<Object> getClauseValue(Parameter param)
-    {
+    public List<Object> getClauseValue(Parameter param) {
         Parameter match = null;
-        if (typedParameter != null && typedParameter.jpaParameters != null)
-        {
-            for (Parameter p : typedParameter.jpaParameters)
-            {
-                if (p.equals(param))
-                {
+        if (typedParameter != null && typedParameter.jpaParameters != null) {
+            for (Parameter p : typedParameter.jpaParameters) {
+                if (p.equals(param)) {
                     match = p;
-                    if (typedParameter.getType().equals(Type.NAMED))
-                    {
+                    if (typedParameter.getType().equals(Type.NAMED)) {
                         List<FilterClause> clauses = typedParameter.getParameters().get(":" + p.getName());
-                        if (clauses != null)
-                        {
+                        if (clauses != null) {
                             return clauses.get(0).getValue();
                         }
-                    }
-                    else
-                    {
+                    } else {
                         List<FilterClause> clauses = typedParameter.getParameters().get("?" + p.getPosition());
-                        if (clauses != null)
-                        {
+                        if (clauses != null) {
                             return clauses.get(0).getValue();
-                        }
-                        else
-                        {
+                        } else {
                             UpdateClause updateClause = typedParameter.getUpdateParameters().get("?" + p.getPosition());
-                            if (updateClause != null)
-                            {
+                            if (updateClause != null) {
                                 List<Object> value = new ArrayList<Object>();
                                 value.add(updateClause.getValue());
                                 return value;
@@ -600,8 +538,7 @@ public class KunderaQuery
                     break;
                 }
             }
-            if (match == null)
-            {
+            if (match == null) {
                 throw new IllegalArgumentException("parameter is not a parameter of the query");
             }
         }
@@ -615,8 +552,7 @@ public class KunderaQuery
     /**
      * Post parsing init.
      */
-    protected void postParsingInit()
-    {
+    protected void postParsingInit() {
         initEntityClass();
         initFilter();
         initUpdateClause();
@@ -625,10 +561,8 @@ public class KunderaQuery
     /**
      * Inits the update clause.
      */
-    private void initUpdateClause()
-    {
-        for (UpdateClause updateClause : updateClauseQueue)
-        {
+    private void initUpdateClause() {
+        for (UpdateClause updateClause : updateClauseQueue) {
 
             onTypedParameter(updateClause.getValue(), updateClause, updateClause.getProperty().trim());
         }
@@ -638,34 +572,27 @@ public class KunderaQuery
     /**
      * Inits the entity class.
      */
-    private void initEntityClass()
-    {
-        if (from == null)
-        {
+    private void initEntityClass() {
+        if (from == null) {
             throw new JPQLParseException("Bad query format FROM clause is mandatory for SELECT queries");
         }
         String fromArray[] = from.split(" ");
 
-        if (!this.isDeleteUpdate)
-        {
-            if (fromArray.length == 3 && fromArray[1].equalsIgnoreCase("as"))
-            {
+        if (!this.isDeleteUpdate) {
+            if (fromArray.length == 3 && fromArray[1].equalsIgnoreCase("as")) {
                 fromArray = new String[] { fromArray[0], fromArray[2] };
             }
 
-            if (fromArray.length != 2)
-            {
+            if (fromArray.length != 2) {
                 throw new JPQLParseException("Bad query format: " + from
-                        + ". Identification variable is mandatory in FROM clause for SELECT queries");
+                    + ". Identification variable is mandatory in FROM clause for SELECT queries");
             }
 
             // TODO
             StringTokenizer tokenizer = new StringTokenizer(result[0], ",");
-            while (tokenizer.hasMoreTokens())
-            {
+            while (tokenizer.hasMoreTokens()) {
                 String token = tokenizer.nextToken();
-                if (!StringUtils.containsAny(fromArray[1] + ".", token))
-                {
+                if (!StringUtils.containsAny(fromArray[1] + ".", token)) {
                     throw new QueryHandlerException("bad query format with invalid alias:" + token);
                 }
             }
@@ -680,39 +607,34 @@ public class KunderaQuery
         // Get specific metamodel.
         MetamodelImpl model = getMetamodel(persistenceUnit);
 
-        if (model != null)
-        {
+        if (model != null) {
             entityClass = model.getEntityClass(entityName);
         }
 
-        if (null == entityClass)
-        {
+        if (null == entityClass) {
             logger.error(
-                    "No entity {} found, please verify it is properly annotated with @Entity and not a mapped Super class",
-                    entityName);
+                "No entity {} found, please verify it is properly annotated with @Entity and not a mapped Super class",
+                entityName);
             throw new QueryHandlerException("No entity found by the name: " + entityName);
         }
 
         EntityMetadata metadata = model.getEntityMetadata(entityClass);
 
-        if (metadata != null && !metadata.isIndexable())
-        {
+        if (metadata != null && !metadata.isIndexable()) {
             throw new QueryHandlerException(entityClass + " is not indexed. Not possible to run a query on it."
-                    + " Check whether it was properly annotated for indexing.");
+                + " Check whether it was properly annotated for indexing.");
         }
     }
 
     /**
      * Inits the filter.
      */
-    private void initFilter()
-    {
+    private void initFilter() {
         EntityMetadata metadata = KunderaMetadataManager.getEntityMetadata(kunderaMetadata, entityClass);
         Metamodel metaModel = kunderaMetadata.getApplicationMetadata().getMetamodel(getPersistenceUnit());
         EntityType entityType = metaModel.entity(entityClass);
 
-        if (null == filter)
-        {
+        if (null == filter) {
             List<String> clauses = new ArrayList<String>();
             addDiscriminatorClause(clauses, entityType);
             return;
@@ -721,11 +643,9 @@ public class KunderaQuery
 
         KunderaQueryUtils.traverse(whereClause.getConditionalExpression(), metadata, kunderaMetadata, this, false);
 
-        for (Object filterClause : filtersQueue)
-        {
+        for (Object filterClause : filtersQueue) {
 
-            if (!(filterClause instanceof String))
-            {
+            if (!(filterClause instanceof String)) {
                 onTypedParameter(((FilterClause) filterClause));
             }
 
@@ -742,17 +662,13 @@ public class KunderaQuery
      * @param entityType
      *            the entity type
      */
-    private void addDiscriminatorClause(List<String> clauses, EntityType entityType)
-    {
-        if (((AbstractManagedType) entityType).isInherited())
-        {
+    private void addDiscriminatorClause(List<String> clauses, EntityType entityType) {
+        if (((AbstractManagedType) entityType).isInherited()) {
             String discrColumn = ((AbstractManagedType) entityType).getDiscriminatorColumn();
             String discrValue = ((AbstractManagedType) entityType).getDiscriminatorValue();
 
-            if (discrColumn != null && discrValue != null)
-            {
-                if (clauses != null && !clauses.isEmpty())
-                {
+            if (discrColumn != null && discrValue != null) {
+                if (clauses != null && !clauses.isEmpty()) {
                     filtersQueue.add("AND");
                 }
 
@@ -763,8 +679,8 @@ public class KunderaQuery
     }
 
     /**
-     * Depending upon filter value, if it starts with ":" then it is NAMED
-     * parameter, else if starts with "?", it will be INDEXED parameter.
+     * Depending upon filter value, if it starts with ":" then it is NAMED parameter, else if starts with "?", it will
+     * be INDEXED parameter.
      * 
      * @param value
      *            the value
@@ -773,47 +689,38 @@ public class KunderaQuery
      * @param fieldName
      *            the field name
      */
-    private void onTypedParameter(Object value, UpdateClause updateClause, String fieldName)
-    {
+    private void onTypedParameter(Object value, UpdateClause updateClause, String fieldName) {
         String token = value.toString();
-        if (token != null && token.startsWith(":"))
-        {
+        if (token != null && token.startsWith(":")) {
             addTypedParameter(Type.NAMED, token, updateClause);
             filterJPAParameterInfo(Type.NAMED, token.substring(1), fieldName);
-        }
-        else if (token != null && token.startsWith("?"))
-        {
+        } else if (token != null && token.startsWith("?")) {
             addTypedParameter(Type.INDEXED, token, updateClause);
             filterJPAParameterInfo(Type.INDEXED, token.substring(1), fieldName);
         }
     }
 
     /**
-     * Depending upon filter value, if it starts with ":" then it is NAMED
-     * parameter, else if starts with "?", it will be INDEXED parameter.
+     * Depending upon filter value, if it starts with ":" then it is NAMED parameter, else if starts with "?", it will
+     * be INDEXED parameter.
      * 
      * @param filterClause
      *            filter clauses.
      */
-    private void onTypedParameter(FilterClause filterClause)
-    {
+    private void onTypedParameter(FilterClause filterClause) {
 
-        if (filterClause.value != null && filterClause.value.get(0) == null)
-        {
+        if (filterClause.value != null && filterClause.value.get(0) == null) {
             return;
         }
 
-        if (filterClause.value != null && filterClause.value.get(0).toString().startsWith(":"))
-        {
+        if (filterClause.value != null && filterClause.value.get(0).toString().startsWith(":")) {
             addTypedParameter(Type.NAMED, filterClause.value.get(0).toString(), filterClause);
             filterJPAParameterInfo(Type.NAMED, filterClause.value.get(0).toString().substring(1),
-                    filterClause.fieldName);
-        }
-        else if (filterClause.value.toString() != null && filterClause.value.get(0).toString().startsWith("?"))
-        {
+                filterClause.fieldName);
+        } else if (filterClause.value.toString() != null && filterClause.value.get(0).toString().startsWith("?")) {
             addTypedParameter(Type.INDEXED, filterClause.value.get(0).toString(), filterClause);
             filterJPAParameterInfo(Type.INDEXED, filterClause.value.get(0).toString().substring(1),
-                    filterClause.fieldName);
+                filterClause.fieldName);
         }
     }
 
@@ -827,19 +734,14 @@ public class KunderaQuery
      * @param clause
      *            filter clause.
      */
-    private void addTypedParameter(Type type, String parameter, FilterClause clause)
-    {
-        if (typedParameter == null)
-        {
+    private void addTypedParameter(Type type, String parameter, FilterClause clause) {
+        if (typedParameter == null) {
             typedParameter = new TypedParameter(type);
         }
 
-        if (typedParameter.getType().equals(type))
-        {
+        if (typedParameter.getType().equals(type)) {
             typedParameter.addParameters(parameter, clause);
-        }
-        else
-        {
+        } else {
             logger.warn("Invalid type provided, it can either be name or indexes!");
         }
     }
@@ -854,21 +756,15 @@ public class KunderaQuery
      * @param clause
      *            filter clause.
      */
-    private void addTypedParameter(Type type, String parameter, UpdateClause clause)
-    {
-        if (type != null)
-        {
-            if (typedParameter == null)
-            {
+    private void addTypedParameter(Type type, String parameter, UpdateClause clause) {
+        if (type != null) {
+            if (typedParameter == null) {
                 typedParameter = new TypedParameter(type);
             }
 
-            if (typedParameter.getType().equals(type))
-            {
+            if (typedParameter.getType().equals(type)) {
                 typedParameter.addParameters(parameter, clause);
-            }
-            else
-            {
+            } else {
                 logger.warn("Invalid type provided, it can either be name or indexes!");
             }
         }
@@ -884,19 +780,16 @@ public class KunderaQuery
      * @param fieldName
      *            the field name
      */
-    private void filterJPAParameterInfo(Type type, String name, String fieldName)
-    {
+    private void filterJPAParameterInfo(Type type, String name, String fieldName) {
         String attributeName = getAttributeName(fieldName);
-        Attribute entityAttribute = ((MetamodelImpl) kunderaMetadata.getApplicationMetadata().getMetamodel(
-                persistenceUnit)).getEntityAttribute(entityClass, attributeName);
+        Attribute entityAttribute =
+            ((MetamodelImpl) kunderaMetadata.getApplicationMetadata().getMetamodel(persistenceUnit))
+                .getEntityAttribute(entityClass, attributeName);
         Class fieldType = entityAttribute.getJavaType();
 
-        if (type.equals(Type.INDEXED))
-        {
+        if (type.equals(Type.INDEXED)) {
             typedParameter.addJPAParameter(new JPAParameter(null, Integer.valueOf(name), fieldType));
-        }
-        else
-        {
+        } else {
             typedParameter.addJPAParameter(new JPAParameter(name, null, fieldType));
         }
     }
@@ -908,11 +801,9 @@ public class KunderaQuery
      *            the field name
      * @return the attribute name
      */
-    private String getAttributeName(String fieldName)
-    {
+    private String getAttributeName(String fieldName) {
         String attributeName = fieldName;
-        if (fieldName.indexOf(".") != -1)
-        {
+        if (fieldName.indexOf(".") != -1) {
             attributeName = fieldName.substring(0, fieldName.indexOf("."));
         }
         return attributeName;
@@ -927,13 +818,12 @@ public class KunderaQuery
      *            the value
      */
 
-    public final void setParameter(String name, Object value)
-    {
+    public final void setParameter(String name, Object value) {
         if (isNative()) {
             bindParameters.add(new BindParameter(name, value));
-	} else {
+        } else {
             setParameterValue(":" + name, value);
-	}
+        }
 
         parametersMap.put(":" + name, value);
     }
@@ -946,13 +836,12 @@ public class KunderaQuery
      * @param value
      *            the value
      */
-    public final void setParameter(int position, Object value)
-    {
-	if (isNative()) {
-	    bindParameters.add(new BindParameter(position, value));
-	} else {
+    public final void setParameter(int position, Object value) {
+        if (isNative()) {
+            bindParameters.add(new BindParameter(position, value));
+        } else {
             setParameterValue("?" + position, value);
-	}
+        }
 
         parametersMap.put("?" + position, value);
     }
@@ -965,35 +854,24 @@ public class KunderaQuery
      * @param value
      *            parameter value.
      */
-    private void setParameterValue(String name, Object value)
-    {
-        if (typedParameter != null)
-        {
-            List<FilterClause> clauses = typedParameter.getParameters() != null ? typedParameter.getParameters().get(
-                    name) : null;
-            if (clauses != null)
-            {
-                for (FilterClause clause : clauses)
-                {
+    private void setParameterValue(String name, Object value) {
+        if (typedParameter != null) {
+            List<FilterClause> clauses =
+                typedParameter.getParameters() != null ? typedParameter.getParameters().get(name) : null;
+            if (clauses != null) {
+                for (FilterClause clause : clauses) {
                     clause.setValue(value);
                 }
-            }
-            else
-            {
-                if (typedParameter.getUpdateParameters() != null)
-                {
+            } else {
+                if (typedParameter.getUpdateParameters() != null) {
                     UpdateClause updateClause = typedParameter.getUpdateParameters().get(name);
                     updateClause.setValue(value);
-                }
-                else
-                {
+                } else {
                     logger.error("Error while setting parameter.");
                     throw new QueryHandlerException("named parameter : " + name + " not found!");
                 }
             }
-        }
-        else
-        {
+        } else {
             throw new QueryHandlerException("No named parameter present for query");
         }
     }
@@ -1003,8 +881,7 @@ public class KunderaQuery
      * 
      * @return the entityClass
      */
-    public final Class getEntityClass()
-    {
+    public final Class getEntityClass() {
         return entityClass;
     }
 
@@ -1013,8 +890,7 @@ public class KunderaQuery
      * 
      * @return the entity alias
      */
-    public final String getEntityAlias()
-    {
+    public final String getEntityAlias() {
         return this.entityAlias;
     }
 
@@ -1023,8 +899,7 @@ public class KunderaQuery
      * 
      * @return true, if is native
      */
-    public boolean isNative()
-    {
+    public boolean isNative() {
         return isNativeQuery;
     }
 
@@ -1033,19 +908,14 @@ public class KunderaQuery
      * 
      * @return the entity metadata
      */
-    public final EntityMetadata getEntityMetadata()
-    {
+    public final EntityMetadata getEntityMetadata() {
         EntityMetadata metadata = null;
-        try
-        {
+        try {
             metadata = KunderaMetadataManager.getEntityMetadata(kunderaMetadata, entityClass);
-        }
-        catch (KunderaException e)
-        {
+        } catch (KunderaException e) {
             logger.info("No Entity class provided, Proceeding as Scalar Query");
         }
-        if (!this.isNativeQuery && metadata == null)
-        {
+        if (!this.isNativeQuery && metadata == null) {
             throw new KunderaException("Unable to load entity metadata for : " + entityClass);
         }
         return metadata;
@@ -1056,16 +926,14 @@ public class KunderaQuery
      * 
      * @return the filters
      */
-    public final Queue getFilterClauseQueue()
-    {
+    public final Queue getFilterClauseQueue() {
         return filtersQueue;
     }
 
     /**
      * The FilterClause class to hold a where clause predicate.
      */
-    public final class FilterClause
-    {
+    public final class FilterClause {
 
         /** The property. */
         private String property;
@@ -1081,8 +949,7 @@ public class KunderaQuery
          * 
          * @return the fieldName
          */
-        public String getFieldName()
-        {
+        public String getFieldName() {
             return fieldName;
         }
 
@@ -1104,21 +971,16 @@ public class KunderaQuery
          * @param fieldName
          *            the field name
          */
-        public FilterClause(String property, String condition, Object value, String fieldName)
-        {
+        public FilterClause(String property, String condition, Object value, String fieldName) {
             super();
             this.property = property;
             this.condition = condition.trim();
             this.fieldName = fieldName;
-            if (value instanceof Collection)
-            {
-                for (Object valueObject : (Collection) value)
-                {
+            if (value instanceof Collection) {
+                for (Object valueObject : (Collection) value) {
                     this.value.add(KunderaQuery.getValue(valueObject));
                 }
-            }
-            else
-            {
+            } else {
                 this.value.add(KunderaQuery.getValue(value));
             }
         }
@@ -1128,8 +990,7 @@ public class KunderaQuery
          * 
          * @return the property
          */
-        public final String getProperty()
-        {
+        public final String getProperty() {
             return property;
         }
 
@@ -1138,8 +999,7 @@ public class KunderaQuery
          * 
          * @return the condition
          */
-        public final String getCondition()
-        {
+        public final String getCondition() {
             return condition;
         }
 
@@ -1148,8 +1008,7 @@ public class KunderaQuery
          * 
          * @return the value
          */
-        public final List<Object> getValue()
-        {
+        public final List<Object> getValue() {
             return value;
         }
 
@@ -1159,18 +1018,13 @@ public class KunderaQuery
          * @param value
          *            the value to set
          */
-        protected void setValue(Object value)
-        {
+        protected void setValue(Object value) {
             List<Object> valObjects = new ArrayList<Object>();
-            if (value instanceof Collection)
-            {
-                for (Object valueObject : (Collection) value)
-                {
+            if (value instanceof Collection) {
+                for (Object valueObject : (Collection) value) {
                     valObjects.add(KunderaQuery.getValue(valueObject));
                 }
-            }
-            else
-            {
+            } else {
                 valObjects.add(KunderaQuery.getValue(value));
             }
 
@@ -1182,18 +1036,17 @@ public class KunderaQuery
          *
          * @return whether to ignore the case when evaluating the filter clause
          */
-        public boolean isIgnoreCase()
-        {
+        public boolean isIgnoreCase() {
             return ignoreCase;
         }
 
         /**
          * Sets whether to ignore the case when evaluating the filter clause.
          *
-         * @param ignoreCase true to ignore the case when evaluating the filter clause
+         * @param ignoreCase
+         *            true to ignore the case when evaluating the filter clause
          */
-        public void setIgnoreCase(final boolean ignoreCase)
-        {
+        public void setIgnoreCase(final boolean ignoreCase) {
             this.ignoreCase = ignoreCase;
         }
 
@@ -1204,8 +1057,7 @@ public class KunderaQuery
          * @see java.lang.Object#toString()
          */
         @Override
-        public String toString()
-        {
+        public String toString() {
             StringBuilder builder = new StringBuilder();
             builder.append("FilterClause [property=");
             builder.append(property);
@@ -1223,8 +1075,7 @@ public class KunderaQuery
     /**
      * The Class UpdateClause.
      */
-    public final class UpdateClause
-    {
+    public final class UpdateClause {
 
         /** The property. */
         private String property;
@@ -1240,8 +1091,7 @@ public class KunderaQuery
          * @param value
          *            the value
          */
-        public UpdateClause(final String property, final Object value)
-        {
+        public UpdateClause(final String property, final Object value) {
             this.property = property;
             this.value = KunderaQuery.getValue(value);
         }
@@ -1251,8 +1101,7 @@ public class KunderaQuery
          * 
          * @return the property
          */
-        public String getProperty()
-        {
+        public String getProperty() {
             return property;
         }
 
@@ -1261,8 +1110,7 @@ public class KunderaQuery
          * 
          * @return the value
          */
-        public Object getValue()
-        {
+        public Object getValue() {
             return value;
         }
 
@@ -1272,8 +1120,7 @@ public class KunderaQuery
          * @param value
          *            the value to set
          */
-        public void setValue(Object value)
-        {
+        public void setValue(Object value) {
             this.value = KunderaQuery.getValue(value);
         }
 
@@ -1286,8 +1133,7 @@ public class KunderaQuery
      * @see java.lang.Object#clone()
      */
     @Override
-    public final Object clone() throws CloneNotSupportedException
-    {
+    public final Object clone() throws CloneNotSupportedException {
         return super.clone();
     }
 
@@ -1298,8 +1144,7 @@ public class KunderaQuery
      * @see java.lang.Object#toString()
      */
     @Override
-    public final String toString()
-    {
+    public final String toString() {
         StringBuilder builder = new StringBuilder();
         builder.append("KunderaQuery [entityName=");
         builder.append(entityName);
@@ -1318,8 +1163,7 @@ public class KunderaQuery
      *            the pu
      * @return the metamodel
      */
-    private MetamodelImpl getMetamodel(String pu)
-    {
+    private MetamodelImpl getMetamodel(String pu) {
         return KunderaMetadataManager.getMetamodel(kunderaMetadata, pu);
     }
 
@@ -1328,8 +1172,7 @@ public class KunderaQuery
      * 
      * @return the persistenceUnits
      */
-    public String getPersistenceUnit()
-    {
+    public String getPersistenceUnit() {
         return persistenceUnit;
     }
 
@@ -1339,8 +1182,7 @@ public class KunderaQuery
      * @param persistenceUnit
      *            the new persistence unit
      */
-    public void setPersistenceUnit(String persistenceUnit)
-    {
+    public void setPersistenceUnit(String persistenceUnit) {
         this.persistenceUnit = persistenceUnit;
     }
 
@@ -1350,34 +1192,27 @@ public class KunderaQuery
      * @param ordering
      *            the ordering
      */
-    private void parseOrdering(String ordering)
-    {
+    private void parseOrdering(String ordering) {
         final String comma = ",";
         final String space = " ";
 
         StringTokenizer tokenizer = new StringTokenizer(ordering, comma);
 
         sortOrders = new ArrayList<KunderaQuery.SortOrdering>();
-        while (tokenizer.hasMoreTokens())
-        {
+        while (tokenizer.hasMoreTokens()) {
             String order = (String) tokenizer.nextElement();
             StringTokenizer token = new StringTokenizer(order, space);
             SortOrder orderType = SortOrder.ASC;
 
             String colName = (String) token.nextElement();
-            while (token.hasMoreElements())
-            {
+            while (token.hasMoreElements()) {
                 String nextOrder = (String) token.nextElement();
 
                 // more spaces given.
-                if (StringUtils.isNotBlank(nextOrder))
-                {
-                    try
-                    {
+                if (StringUtils.isNotBlank(nextOrder)) {
+                    try {
                         orderType = SortOrder.valueOf(nextOrder.toUpperCase());
-                    }
-                    catch (IllegalArgumentException e)
-                    {
+                    } catch (IllegalArgumentException e) {
                         logger.error("Error while parsing order by clause:");
                         throw new JPQLParseException("Invalid sort order provided:" + nextOrder);
                     }
@@ -1390,8 +1225,7 @@ public class KunderaQuery
     /**
      * Containing SortOrder.
      */
-    public class SortOrdering
-    {
+    public class SortOrdering {
 
         /** The column name. */
         String columnName;
@@ -1407,8 +1241,7 @@ public class KunderaQuery
          * @param order
          *            the order
          */
-        public SortOrdering(String columnName, SortOrder order)
-        {
+        public SortOrdering(String columnName, SortOrder order) {
             this.columnName = columnName;
             this.order = order;
         }
@@ -1418,8 +1251,7 @@ public class KunderaQuery
          * 
          * @return the column name
          */
-        public String getColumnName()
-        {
+        public String getColumnName() {
             return columnName;
         }
 
@@ -1428,8 +1260,7 @@ public class KunderaQuery
          * 
          * @return the order
          */
-        public SortOrder getOrder()
-        {
+        public SortOrder getOrder() {
             return order;
         }
     }
@@ -1437,12 +1268,11 @@ public class KunderaQuery
     /**
      * The Enum SortOrder.
      */
-    public enum SortOrder
-    {
-        /** The ASC. */
-        ASC,
-        /** The DESC. */
-        DESC;
+    public enum SortOrder {
+                           /** The ASC. */
+                           ASC,
+                           /** The DESC. */
+                           DESC;
     }
 
     /**
@@ -1450,8 +1280,7 @@ public class KunderaQuery
      * 
      * @return the updateClauseQueue
      */
-    public Queue<UpdateClause> getUpdateClauseQueue()
-    {
+    public Queue<UpdateClause> getUpdateClauseQueue() {
         return updateClauseQueue;
     }
 
@@ -1460,8 +1289,7 @@ public class KunderaQuery
      * 
      * @return true, if is update clause
      */
-    public boolean isUpdateClause()
-    {
+    public boolean isUpdateClause() {
         return !updateClauseQueue.isEmpty();
     }
 
@@ -1473,12 +1301,12 @@ public class KunderaQuery
      * @param value
      *            the value
      */
-    public void addUpdateClause(final String property, final String value)
-    {
+    public void addUpdateClause(final String property, final String value) {
         UpdateClause updateClause = new UpdateClause(property.trim(), value.trim());
         updateClauseQueue.add(updateClause);
-        addTypedParameter(value.trim().startsWith("?") ? Type.INDEXED : value.trim().startsWith(":") ? Type.NAMED
-                : null, property, updateClause);
+        addTypedParameter(
+            value.trim().startsWith("?") ? Type.INDEXED : value.trim().startsWith(":") ? Type.NAMED : null, property,
+            updateClause);
     }
 
     /**
@@ -1496,16 +1324,12 @@ public class KunderaQuery
      *            to ignore case in the filter
      */
     public void addFilterClause(final String property, final String condition, final Object value,
-            final String fieldName, final boolean ignoreCase)
-    {
-        if (property != null && condition != null)
-        {
+        final String fieldName, final boolean ignoreCase) {
+        if (property != null && condition != null) {
             FilterClause filterClause = new FilterClause(property.trim(), condition.trim(), value, fieldName);
             filterClause.setIgnoreCase(ignoreCase);
             filtersQueue.add(filterClause);
-        }
-        else
-        {
+        } else {
             filtersQueue.add(property);
         }
     }
@@ -1516,8 +1340,7 @@ public class KunderaQuery
      * @param filterClause
      *            the filter clause
      */
-    public void addFilterClause(Object filterClause)
-    {
+    public void addFilterClause(Object filterClause) {
 
         filtersQueue.add(filterClause);
 
@@ -1529,8 +1352,7 @@ public class KunderaQuery
      * @param b
      *            the new checks if is delete update
      */
-    public void setIsDeleteUpdate(boolean b)
-    {
+    public void setIsDeleteUpdate(boolean b) {
         this.isDeleteUpdate = b;
     }
 
@@ -1539,8 +1361,7 @@ public class KunderaQuery
      * 
      * @return true, if is delete update
      */
-    public boolean isDeleteUpdate()
-    {
+    public boolean isDeleteUpdate() {
         return isDeleteUpdate;
     }
 
@@ -1549,16 +1370,14 @@ public class KunderaQuery
      * 
      * @return the JPA query
      */
-    public String getJPAQuery()
-    {
+    public String getJPAQuery() {
         return this.jpaQuery;
     }
 
     /**
      * The Class TypedParameter.
      */
-    private class TypedParameter
-    {
+    private class TypedParameter {
 
         /** The type. */
         private Type type;
@@ -1578,8 +1397,7 @@ public class KunderaQuery
          * @param type
          *            the type
          */
-        public TypedParameter(Type type)
-        {
+        public TypedParameter(Type type) {
             this.type = type;
         }
 
@@ -1588,8 +1406,7 @@ public class KunderaQuery
          * 
          * @return the type
          */
-        private Type getType()
-        {
+        private Type getType() {
             return type;
         }
 
@@ -1598,8 +1415,7 @@ public class KunderaQuery
          * 
          * @return the parameters
          */
-        Map<String, List<FilterClause>> getParameters()
-        {
+        Map<String, List<FilterClause>> getParameters() {
             return parameters;
         }
 
@@ -1608,8 +1424,7 @@ public class KunderaQuery
          * 
          * @return the parameters
          */
-        Map<String, UpdateClause> getUpdateParameters()
-        {
+        Map<String, UpdateClause> getUpdateParameters() {
             return updateParameters;
         }
 
@@ -1621,14 +1436,11 @@ public class KunderaQuery
          * @param clause
          *            the clause
          */
-        void addParameters(String key, FilterClause clause)
-        {
-            if (parameters == null)
-            {
+        void addParameters(String key, FilterClause clause) {
+            if (parameters == null) {
                 parameters = new HashMap<String, List<FilterClause>>();
             }
-            if (!parameters.containsKey(key))
-            {
+            if (!parameters.containsKey(key)) {
                 parameters.put(key, new ArrayList<KunderaQuery.FilterClause>());
             }
             parameters.get(key).add(clause);
@@ -1642,10 +1454,8 @@ public class KunderaQuery
          * @param clause
          *            the clause
          */
-        void addParameters(String key, UpdateClause clause)
-        {
-            if (updateParameters == null)
-            {
+        void addParameters(String key, UpdateClause clause) {
+            if (updateParameters == null) {
                 updateParameters = new HashMap<String, UpdateClause>();
             }
 
@@ -1658,8 +1468,7 @@ public class KunderaQuery
          * @param param
          *            the param
          */
-        void addJPAParameter(Parameter param)
-        {
+        void addJPAParameter(Parameter param) {
             jpaParameters.add(param);
         }
     }
@@ -1667,13 +1476,12 @@ public class KunderaQuery
     /**
      * The Enum Type.
      */
-    private enum Type
-    {
+    private enum Type {
 
-        /** The indexed. */
-        INDEXED,
-        /** The named. */
-        NAMED
+                       /** The indexed. */
+                       INDEXED,
+                       /** The named. */
+                       NAMED
     }
 
     /*
@@ -1685,8 +1493,7 @@ public class KunderaQuery
      * @param <T>
      *            the generic type
      */
-    private class JPAParameter<T> implements Parameter<T>
-    {
+    private class JPAParameter<T> implements Parameter<T> {
 
         /** The name. */
         private String name;
@@ -1707,8 +1514,7 @@ public class KunderaQuery
          * @param type
          *            the type
          */
-        JPAParameter(String name, Integer position, Class<T> type)
-        {
+        JPAParameter(String name, Integer position, Class<T> type) {
             this.name = name;
             this.position = position;
             this.type = type;
@@ -1720,8 +1526,7 @@ public class KunderaQuery
          * @see javax.persistence.Parameter#getName()
          */
         @Override
-        public String getName()
-        {
+        public String getName() {
             return name;
         }
 
@@ -1731,8 +1536,7 @@ public class KunderaQuery
          * @see javax.persistence.Parameter#getPosition()
          */
         @Override
-        public Integer getPosition()
-        {
+        public Integer getPosition() {
             return position;
         }
 
@@ -1742,8 +1546,7 @@ public class KunderaQuery
          * @see javax.persistence.Parameter#getParameterType()
          */
         @Override
-        public Class<T> getParameterType()
-        {
+        public Class<T> getParameterType() {
             return type;
         }
 
@@ -1753,8 +1556,7 @@ public class KunderaQuery
          * @see java.lang.Object#hashCode()
          */
         @Override
-        public int hashCode()
-        {
+        public int hashCode() {
             return HashCodeBuilder.reflectionHashCode(this);
         }
 
@@ -1764,27 +1566,20 @@ public class KunderaQuery
          * @see java.lang.Object#equals(java.lang.Object)
          */
         @Override
-        public boolean equals(Object obj)
-        {
-            if (obj == null)
-            {
+        public boolean equals(Object obj) {
+            if (obj == null) {
                 return false;
             }
-            if (!obj.getClass().equals(this.getClass()))
-            {
+            if (!obj.getClass().equals(this.getClass())) {
                 return false;
             }
 
             Parameter<?> typed = (Parameter<?>) obj;
 
-            if (typed.getParameterType().equals(this.getParameterType()))
-            {
-                if (this.getName() == null && typed.getName() == null)
-                {
+            if (typed.getParameterType().equals(this.getParameterType())) {
+                if (this.getName() == null && typed.getName() == null) {
                     return this.getPosition() != null && this.getPosition().equals(typed.getPosition());
-                }
-                else
-                {
+                } else {
                     return this.getName() != null && this.getName().equals(typed.getName());
                 }
 
@@ -1799,8 +1594,7 @@ public class KunderaQuery
          * @see java.lang.Object#toString()
          */
         @Override
-        public String toString()
-        {
+        public String toString() {
             StringBuilder strBuilder = new StringBuilder();
             strBuilder.append("[ name = " + this.getName() + "]");
             strBuilder.append("[ position = " + this.getPosition() + "]");
@@ -1810,69 +1604,59 @@ public class KunderaQuery
     }
 
     /**
-     * Method to skip string literal as per JPA specification. if literal starts
-     * is enclose within "''" then skip "'" and include "'" in case of "''"
-     * replace it with "'".
+     * Method to skip string literal as per JPA specification. if literal starts is enclose within "''" then skip "'"
+     * and include "'" in case of "''" replace it with "'".
      * 
      * @param value
      *            value.
      * 
-     * @return replaced string in case of string, else will return original
-     *         value.
+     * @return replaced string in case of string, else will return original value.
      */
-    private static Object getValue(Object value)
-    {
-        if (value != null && value.getClass().isAssignableFrom(String.class))
-        {
+    private static Object getValue(Object value) {
+        if (value != null && value.getClass().isAssignableFrom(String.class)) {
             return ((String) value).replaceAll("^'", "").replaceAll("'$", "").replaceAll("''", "'");
         }
 
         return value;
     }
 
-
-
     /*
-     * XXX
-     * Indexed or named bind parameter for queries
+     * XXX Indexed or named bind parameter for queries
      */
 
     public static class BindParameter implements java.io.Serializable {
 
-	    private final String name;
-	    private final int index;
-	    private final Object value;
+        private final String name;
+        private final int index;
+        private final Object value;
 
+        public BindParameter(final String name, final Object value) {
+            this.name = name;
+            this.index = -1;
+            this.value = value;
+        }
 
-	    public BindParameter(final String name, final Object value) {
-		    this.name = name;
-		    this.index = -1;
-		    this.value = value;
-	    }
+        public BindParameter(final int index, final Object value) {
+            this.name = null;
+            this.index = index;
+            this.value = value;
+        }
 
-	    public BindParameter(final int index, final Object value) {
-		    this.name = null;
-		    this.index = index;
-		    this.value = value;
-	    }
+        public String getName() {
+            return name;
+        }
 
+        public boolean isNamed() {
+            return (getName() != null);
+        }
 
-	    public String getName() {
-		    return name;
-	    }
+        public int getIndex() {
+            return index;
+        }
 
-	    public boolean isNamed() {
-		    return (getName() != null);
-	    }
-
-	    public int getIndex() {
-		    return index;
-	    }
-
-	    public Object getValue() {
-		    return value;
-	    }
+        public Object getValue() {
+            return value;
+        }
     }
-
 
 }

--- a/src/jpa-engine/core/src/main/java/com/impetus/kundera/query/KunderaQuery.java
+++ b/src/jpa-engine/core/src/main/java/com/impetus/kundera/query/KunderaQuery.java
@@ -1839,6 +1839,11 @@ public class KunderaQuery
 
     public static class BindParameter implements java.io.Serializable {
 
+	    private final String name;
+	    private final int index;
+	    private final Object value;
+
+
 	    public BindParameter(final String name, final Object value) {
 		    this.name = name;
 		    this.index = -1;
@@ -1852,8 +1857,6 @@ public class KunderaQuery
 	    }
 
 
-	    private final String name;
-
 	    public String getName() {
 		    return name;
 	    }
@@ -1862,15 +1865,9 @@ public class KunderaQuery
 		    return (getName() != null);
 	    }
 
-
-	    private final int index;
-
 	    public int getIndex() {
 		    return index;
 	    }
-
-
-	    private final Object value;
 
 	    public Object getValue() {
 		    return value;

--- a/src/kundera-cassandra/cassandra-core/src/main/java/com/impetus/client/cassandra/CassandraClientBase.java
+++ b/src/kundera-cassandra/cassandra-core/src/main/java/com/impetus/client/cassandra/CassandraClientBase.java
@@ -112,6 +112,8 @@ import com.impetus.kundera.property.PropertyAccessorHelper;
 import com.impetus.kundera.property.accessor.StringAccessor;
 import com.impetus.kundera.utils.KunderaCoreUtils;
 import com.impetus.kundera.utils.TimestampGenerator;
+import com.impetus.kundera.query.KunderaQuery;
+
 
 /**
  * Base Class for all Cassandra Clients Contains methods that are applicable to
@@ -1559,6 +1561,17 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      */
     public abstract List executeQuery(Class clazz, List<String> relationalField, boolean isNative, String cqlQuery);
 
+    // XXX
+    public List executeQuery(
+	Class clazz,
+	List<String> relationalField,
+	boolean isNative,
+	String cqlQuery,
+	final List<KunderaQuery.BindParameter> parameters
+    ) {
+            throw new KunderaException("not implemented");
+    }
+
     /**
      * Find.
      * 
@@ -2579,6 +2592,30 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
         }
         return entities;
     }
+
+
+    // XXX
+    /**
+     * Execute with bind parameters
+     * 
+     * @param <T>
+     *            the generic type
+     * @param query
+     *            the query
+     * @param connection
+     *            the connection
+     * @return the t
+     */
+    public <T> T execute(
+	final String query,
+	final Object connection,
+	final List<KunderaQuery.BindParameter> parameters
+    ) {
+	throw new KunderaException("not implemented");
+    }
+
+ 
+
 
     /**
      * Execute.

--- a/src/kundera-cassandra/cassandra-core/src/main/java/com/impetus/client/cassandra/CassandraClientBase.java
+++ b/src/kundera-cassandra/cassandra-core/src/main/java/com/impetus/client/cassandra/CassandraClientBase.java
@@ -114,15 +114,13 @@ import com.impetus.kundera.utils.KunderaCoreUtils;
 import com.impetus.kundera.utils.TimestampGenerator;
 import com.impetus.kundera.query.KunderaQuery;
 
-
 /**
- * Base Class for all Cassandra Clients Contains methods that are applicable to
- * (but not specific to) different Cassandra clients.
+ * Base Class for all Cassandra Clients Contains methods that are applicable to (but not specific to) different
+ * Cassandra clients.
  * 
  * @author amresh.singh
  */
-public abstract class CassandraClientBase extends ClientBase implements ClientPropertiesSetter
-{
+public abstract class CassandraClientBase extends ClientBase implements ClientPropertiesSetter {
 
     /** log for this class. */
     private static Logger log = LoggerFactory.getLogger(CassandraClientBase.class);
@@ -173,8 +171,7 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      *            the generator
      */
     protected CassandraClientBase(String persistenceUnit, Map<String, Object> externalProperties,
-            final KunderaMetadata kunderaMetadata, final TimestampGenerator generator)
-    {
+        final KunderaMetadata kunderaMetadata, final TimestampGenerator generator) {
         super(kunderaMetadata, externalProperties, persistenceUnit);
         this.cqlClient = new CQLClient();
         this.generator = generator;
@@ -195,8 +192,7 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      * @throws PropertyAccessException
      *             the property access exception
      */
-    protected Column populateFkey(String rlName, Object rlValue, long timestamp) throws PropertyAccessException
-    {
+    protected Column populateFkey(String rlName, Object rlValue, long timestamp) throws PropertyAccessException {
         Column col = new Column();
         col.setName(PropertyAccessorFactory.STRING.toBytes(rlName));
         col.setValue(PropertyAccessorHelper.getBytes(rlValue));
@@ -218,14 +214,11 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      * @return the list
      */
     protected List<Object> onCounterColumn(EntityMetadata m, boolean isRelation, List<String> relations,
-            List<KeySlice> ks)
-    {
+        List<KeySlice> ks) {
         List<Object> entities;
 
-        if (m.getType().isSuperColumnFamilyMetadata())
-        {
-            if (log.isInfoEnabled())
-            {
+        if (m.getType().isSuperColumnFamilyMetadata()) {
+            if (log.isInfoEnabled()) {
                 log.info("On counter column for super column family of entity {}.", m.getEntityClazz());
             }
 
@@ -233,11 +226,9 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
             Map<byte[], List<CounterSuperColumn>> results = new HashMap<byte[], List<CounterSuperColumn>>();
 
             List<CounterSuperColumn> counterColumns = null;
-            for (KeySlice slice : ks)
-            {
+            for (KeySlice slice : ks) {
                 counterColumns = new ArrayList<CounterSuperColumn>(slice.getColumnsSize());
-                for (ColumnOrSuperColumn column : slice.columns)
-                {
+                for (ColumnOrSuperColumn column : slice.columns) {
                     counterColumns.add(column.counter_super_column);
                 }
 
@@ -246,21 +237,17 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
 
             entities = new ArrayList<Object>(results.size());
 
-            for (byte[] key : results.keySet())
-            {
+            for (byte[] key : results.keySet()) {
                 Object e = null;
                 Object id = PropertyAccessorHelper.getObject(m.getIdAttribute().getJavaType(), key);
                 List<CounterSuperColumn> counterSuperColumns = results.get(key);
                 ThriftRow tr = new ThriftRow(id, m.getTableName(), new ArrayList<Column>(0),
-                        new ArrayList<SuperColumn>(0), new ArrayList<CounterColumn>(0), counterSuperColumns);
+                    new ArrayList<SuperColumn>(0), new ArrayList<CounterColumn>(0), counterSuperColumns);
                 e = getDataHandler().populateEntity(tr, m, KunderaCoreUtils.getEntity(e), relations, isRelation);
                 entities.add(e);
             }
-        }
-        else
-        {
-            if (log.isInfoEnabled())
-            {
+        } else {
+            if (log.isInfoEnabled()) {
                 log.info("On counter column for column family of entity {}", m.getEntityClazz());
             }
 
@@ -268,11 +255,9 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
 
             List<CounterColumn> counterColumns = null;
 
-            for (KeySlice slice : ks)
-            {
+            for (KeySlice slice : ks) {
                 counterColumns = new ArrayList<CounterColumn>(slice.getColumnsSize());
-                for (ColumnOrSuperColumn column : slice.columns)
-                {
+                for (ColumnOrSuperColumn column : slice.columns) {
                     counterColumns.add(column.counter_column);
                 }
 
@@ -281,18 +266,16 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
 
             entities = new ArrayList<Object>(results.size());
 
-            for (byte[] key : results.keySet())
-            {
+            for (byte[] key : results.keySet()) {
                 Object e = null;
                 Object id = PropertyAccessorHelper.getObject(m.getIdAttribute().getJavaType(), key);
 
                 List<CounterColumn> columns = results.get(key);
                 ThriftRow tr = new ThriftRow(id, m.getTableName(), new ArrayList<Column>(0),
-                        new ArrayList<SuperColumn>(0), columns, new ArrayList<CounterSuperColumn>(0));
+                    new ArrayList<SuperColumn>(0), columns, new ArrayList<CounterSuperColumn>(0));
                 e = getDataHandler().populateEntity(tr, m, KunderaCoreUtils.getEntity(e), relations, isRelation);
 
-                if (e != null)
-                {
+                if (e != null) {
                     entities.add(e);
                 }
             }
@@ -315,17 +298,15 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      *            the q results
      */
     protected void computeEntityViaColumns(EntityMetadata m, boolean isRelation, List<String> relations,
-            List<Object> entities, Map<ByteBuffer, List<Column>> qResults)
-    {
-        MetamodelImpl metaModel = (MetamodelImpl) kunderaMetadata.getApplicationMetadata().getMetamodel(
-                m.getPersistenceUnit());
+        List<Object> entities, Map<ByteBuffer, List<Column>> qResults) {
+        MetamodelImpl metaModel =
+            (MetamodelImpl) kunderaMetadata.getApplicationMetadata().getMetamodel(m.getPersistenceUnit());
 
         EntityType entityType = metaModel.entity(m.getEntityClazz());
 
         List<AbstractManagedType> subManagedType = ((AbstractManagedType) entityType).getSubManagedType();
 
-        for (ByteBuffer key : qResults.keySet())
-        {
+        for (ByteBuffer key : qResults.keySet()) {
             onColumn(m, isRelation, relations, entities, qResults.get(key), subManagedType, key);
         }
     }
@@ -349,42 +330,33 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      *            the key
      */
     protected void onColumn(EntityMetadata m, boolean isRelation, List<String> relations, List<Object> entities,
-            List<Column> columns, List<AbstractManagedType> subManagedType, ByteBuffer key)
-    {
-        if (!columns.isEmpty())
-        {
+        List<Column> columns, List<AbstractManagedType> subManagedType, ByteBuffer key) {
+        if (!columns.isEmpty()) {
             Object id = PropertyAccessorHelper.getObject(m.getIdAttribute().getJavaType(), key.array());
             ThriftRow tr = new ThriftRow(id, m.getTableName(), columns, new ArrayList<SuperColumn>(0),
-                    new ArrayList<CounterColumn>(0), new ArrayList<CounterSuperColumn>(0));
+                new ArrayList<CounterColumn>(0), new ArrayList<CounterSuperColumn>(0));
             Object o = null;
 
-            if (!subManagedType.isEmpty())
-            {
-                for (AbstractManagedType subEntity : subManagedType)
-                {
-                    EntityMetadata subEntityMetadata = KunderaMetadataManager.getEntityMetadata(kunderaMetadata,
-                            subEntity.getJavaType());
+            if (!subManagedType.isEmpty()) {
+                for (AbstractManagedType subEntity : subManagedType) {
+                    EntityMetadata subEntityMetadata =
+                        KunderaMetadataManager.getEntityMetadata(kunderaMetadata, subEntity.getJavaType());
 
                     o = getDataHandler().populateEntity(tr, subEntityMetadata, KunderaCoreUtils.getEntity(o),
-                            subEntityMetadata.getRelationNames(), isRelation);
-                    if (o != null)
-                    {
+                        subEntityMetadata.getRelationNames(), isRelation);
+                    if (o != null) {
                         break;
                     }
                 }
-            }
-            else
-            {
+            } else {
                 o = getDataHandler().populateEntity(tr, m, KunderaCoreUtils.getEntity(o), relations, isRelation);
             }
 
-            if (log.isInfoEnabled())
-            {
+            if (log.isInfoEnabled()) {
                 log.info("Populating data for entity of clazz {} and row key {}.", m.getEntityClazz(), tr.getId());
             }
 
-            if (o != null)
-            {
+            if (o != null) {
                 entities.add(o);
             }
         }
@@ -405,10 +377,8 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      *            the q results
      */
     protected void computeEntityViaSuperColumns(EntityMetadata m, boolean isRelation, List<String> relations,
-            List<Object> entities, Map<ByteBuffer, List<SuperColumn>> qResults)
-    {
-        for (ByteBuffer key : qResults.keySet())
-        {
+        List<Object> entities, Map<ByteBuffer, List<SuperColumn>> qResults) {
+        for (ByteBuffer key : qResults.keySet()) {
             onSuperColumn(m, isRelation, relations, entities, qResults.get(key), key);
         }
     }
@@ -430,23 +400,20 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      *            the key
      */
     protected void onSuperColumn(EntityMetadata m, boolean isRelation, List<String> relations, List<Object> entities,
-            List<SuperColumn> superColumns, ByteBuffer key)
-    {
+        List<SuperColumn> superColumns, ByteBuffer key) {
         Object e = null;
         Object id = PropertyAccessorHelper.getObject(m.getIdAttribute().getJavaType(), key.array());
 
         ThriftRow tr = new ThriftRow(id, m.getTableName(), new ArrayList<Column>(0), superColumns,
-                new ArrayList<CounterColumn>(0), new ArrayList<CounterSuperColumn>(0));
+            new ArrayList<CounterColumn>(0), new ArrayList<CounterSuperColumn>(0));
 
         e = getDataHandler().populateEntity(tr, m, KunderaCoreUtils.getEntity(e), relations, isRelation);
-        if (log.isInfoEnabled())
-        {
+        if (log.isInfoEnabled()) {
             log.info("Populating data for super column family of clazz {} and row key {}.", m.getEntityClazz(),
-                    tr.getId());
+                tr.getId());
         }
 
-        if (e != null)
-        {
+        if (e != null) {
             entities.add(e);
         }
     }
@@ -461,46 +428,33 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      * @param relations
      *            the relations
      */
-    protected void addRelationsToThriftRow(EntityMetadata metadata, ThriftRow tf, List<RelationHolder> relations)
-    {
-        if (relations != null)
-        {
+    protected void addRelationsToThriftRow(EntityMetadata metadata, ThriftRow tf, List<RelationHolder> relations) {
+        if (relations != null) {
             long timestamp = generator.getTimestamp();
-            MetamodelImpl metaModel = (MetamodelImpl) kunderaMetadata.getApplicationMetadata().getMetamodel(
-                    metadata.getPersistenceUnit());
-            for (RelationHolder rh : relations)
-            {
+            MetamodelImpl metaModel =
+                (MetamodelImpl) kunderaMetadata.getApplicationMetadata().getMetamodel(metadata.getPersistenceUnit());
+            for (RelationHolder rh : relations) {
                 String linkName = rh.getRelationName();
                 Object linkValue = rh.getRelationValue();
 
-                if (linkName != null && linkValue != null)
-                {
-                    if (metaModel.getEmbeddables(metadata.getEntityClazz()).isEmpty())
-                    {
-                        if (metadata.isCounterColumnType())
-                        {
+                if (linkName != null && linkValue != null) {
+                    if (metaModel.getEmbeddables(metadata.getEntityClazz()).isEmpty()) {
+                        if (metadata.isCounterColumnType()) {
                             CounterColumn col = populateCounterFkey(linkName, linkValue);
                             tf.addCounterColumn(col);
-                        }
-                        else
-                        {
+                        } else {
                             Column col = populateFkey(linkName, linkValue, timestamp);
                             tf.addColumn(col);
                         }
 
-                    }
-                    else
-                    {
-                        if (metadata.isCounterColumnType())
-                        {
+                    } else {
+                        if (metadata.isCounterColumnType()) {
                             CounterSuperColumn counterSuperColumn = new CounterSuperColumn();
                             counterSuperColumn.setName(linkName.getBytes());
                             CounterColumn column = populateCounterFkey(linkName, linkValue);
                             counterSuperColumn.addToColumns(column);
                             tf.addCounterSuperColumn(counterSuperColumn);
-                        }
-                        else
-                        {
+                        } else {
                             SuperColumn superColumn = new SuperColumn();
                             superColumn.setName(linkName.getBytes());
                             Column column = populateFkey(linkName, linkValue, timestamp);
@@ -522,8 +476,7 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      *            the rl value
      * @return the counter column
      */
-    private CounterColumn populateCounterFkey(String rlName, Object rlValue)
-    {
+    private CounterColumn populateCounterFkey(String rlName, Object rlValue) {
         CounterColumn counterCol = new CounterColumn();
         counterCol.setName(PropertyAccessorFactory.STRING.toBytes(rlName));
         counterCol.setValue((Long) rlValue);
@@ -543,33 +496,26 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      *            the consistency level
      */
     protected void deleteRecordFromCounterColumnFamily(Object pKey, String tableName, EntityMetadata metadata,
-            ConsistencyLevel consistencyLevel)
-    {
+        ConsistencyLevel consistencyLevel) {
         ColumnPath path = new ColumnPath(tableName);
 
         Cassandra.Client conn = null;
         Object pooledConnection = null;
-        try
-        {
+        try {
             pooledConnection = getConnection();
             conn = (org.apache.cassandra.thrift.Cassandra.Client) getConnection(pooledConnection);
 
-            if (log.isInfoEnabled())
-            {
+            if (log.isInfoEnabled()) {
                 log.info("Removing data for counter column family {}.", tableName);
             }
 
             conn.remove_counter((CassandraUtilities.toBytes(pKey, metadata.getIdAttribute().getJavaType())), path,
-                    consistencyLevel);
+                consistencyLevel);
 
-        }
-        catch (Exception e)
-        {
+        } catch (Exception e) {
             log.error("Error during executing delete, Caused by: .", e);
             throw new PersistenceException(e);
-        }
-        finally
-        {
+        } finally {
             releaseConnection(pooledConnection);
         }
     }
@@ -586,11 +532,9 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      * @param columnType
      *            the column type
      */
-    protected void createIndexesOnColumns(EntityMetadata m, String tableName, List<Column> columns, Class columnType)
-    {
+    protected void createIndexesOnColumns(EntityMetadata m, String tableName, List<Column> columns, Class columnType) {
         Object pooledConnection = null;
-        try
-        {
+        try {
             Cassandra.Client api = null;
             pooledConnection = getConnection();
             api = (org.apache.cassandra.thrift.Cassandra.Client) getConnection(pooledConnection);
@@ -601,17 +545,14 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
             // required
             CfDef columnFamilyDefToUpdate = null;
             boolean isUpdatable = false;
-            for (CfDef cfDef : cfDefs)
-            {
-                if (cfDef.getName().equals(tableName))
-                {
+            for (CfDef cfDef : cfDefs) {
+                if (cfDef.getName().equals(tableName)) {
                     columnFamilyDefToUpdate = cfDef;
                     break;
                 }
             }
 
-            if (columnFamilyDefToUpdate == null)
-            {
+            if (columnFamilyDefToUpdate == null) {
                 log.error("Join table {} not available.", tableName);
                 throw new PersistenceException("table" + tableName + " not found!");
             }
@@ -621,10 +562,8 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
             List<ColumnDef> columnMetadataList = columnFamilyDefToUpdate.getColumn_metadata();
             List<String> indexList = new ArrayList<String>();
 
-            if (columnMetadataList != null)
-            {
-                for (ColumnDef columnDef : columnMetadataList)
-                {
+            if (columnMetadataList != null) {
+                for (ColumnDef columnDef : columnMetadataList) {
                     indexList.add(new StringAccessor().fromBytes(String.class, columnDef.getName()));
                 }
                 // need to set them to null else it is giving problem on update
@@ -633,8 +572,7 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
             }
 
             // Iterate over all columns for creating secondary index on them
-            for (Column column : columns)
-            {
+            for (Column column : columns) {
 
                 ColumnDef columnDef = new ColumnDef();
 
@@ -645,8 +583,7 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
                 // Add secondary index only if it's not already created
                 // (if already created, it would be there in column family
                 // definition)
-                if (!indexList.contains(new StringAccessor().fromBytes(String.class, column.getName())))
-                {
+                if (!indexList.contains(new StringAccessor().fromBytes(String.class, column.getName()))) {
                     isUpdatable = true;
                     columnFamilyDefToUpdate.addToColumn_metadata(columnDef);
                 }
@@ -654,21 +591,16 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
 
             // Finally, update column family with modified column family
             // definition
-            if (isUpdatable)
-            {
-                columnFamilyDefToUpdate.setKey_validation_class(CassandraValidationClassMapper.getValidationClass(m
-                        .getIdAttribute().getJavaType(), isCql3Enabled(m)));
+            if (isUpdatable) {
+                columnFamilyDefToUpdate.setKey_validation_class(CassandraValidationClassMapper
+                    .getValidationClass(m.getIdAttribute().getJavaType(), isCql3Enabled(m)));
                 api.system_update_column_family(columnFamilyDefToUpdate);
             }
 
-        }
-        catch (Exception e)
-        {
+        } catch (Exception e) {
             log.warn("Could not create secondary index on column family {}, Caused by: . ", tableName, e);
 
-        }
-        finally
-        {
+        } finally {
             releaseConnection(pooledConnection);
         }
     }
@@ -682,8 +614,7 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      *            the row id
      * @return the object
      */
-    public Object find(Class entityClass, Object rowId)
-    {
+    public Object find(Class entityClass, Object rowId) {
         EntityMetadata entityMetadata = KunderaMetadataManager.getEntityMetadata(kunderaMetadata, entityClass);
         List<String> relationNames = entityMetadata.getRelationNames();
         return find(entityClass, entityMetadata, rowId, relationNames);
@@ -702,12 +633,12 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      *            the row ids
      * @return the list
      */
-    public <E> List<E> findAll(Class<E> entityClass, String[] columnsToSelect, Object... rowIds)
-    {
+    public <E> List<E> findAll(Class<E> entityClass, String[] columnsToSelect, Object... rowIds) {
         EntityMetadata entityMetadata = KunderaMetadataManager.getEntityMetadata(kunderaMetadata, entityClass);
         List<E> results = new ArrayList<E>();
-        results = find(entityClass, entityMetadata.getRelationNames(), entityMetadata.getRelationNames() != null
-                && !entityMetadata.getRelationNames().isEmpty(), entityMetadata, rowIds);
+        results = find(entityClass, entityMetadata.getRelationNames(),
+            entityMetadata.getRelationNames() != null && !entityMetadata.getRelationNames().isEmpty(), entityMetadata,
+            rowIds);
         return results.isEmpty() ? null : results;
     }
 
@@ -724,41 +655,32 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      *            the relation names
      * @return the object
      */
-    private final Object find(Class<?> clazz, EntityMetadata metadata, Object rowId, List<String> relationNames)
-    {
+    private final Object find(Class<?> clazz, EntityMetadata metadata, Object rowId, List<String> relationNames) {
 
         List<Object> result = null;
-        try
-        {
-            MetamodelImpl metaModel = (MetamodelImpl) kunderaMetadata.getApplicationMetadata().getMetamodel(
-                    metadata.getPersistenceUnit());
+        try {
+            MetamodelImpl metaModel =
+                (MetamodelImpl) kunderaMetadata.getApplicationMetadata().getMetamodel(metadata.getPersistenceUnit());
 
             EntityType entityType = metaModel.entity(clazz);
 
             List<ManagedType> subTypes = ((AbstractManagedType) entityType).getSubManagedType();
 
-            if (!subTypes.isEmpty())
-            {
-                for (ManagedType subEntity : subTypes)
-                {
-                    EntityMetadata subEntityMetadata = KunderaMetadataManager.getEntityMetadata(kunderaMetadata,
-                            subEntity.getJavaType());
+            if (!subTypes.isEmpty()) {
+                for (ManagedType subEntity : subTypes) {
+                    EntityMetadata subEntityMetadata =
+                        KunderaMetadataManager.getEntityMetadata(kunderaMetadata, subEntity.getJavaType());
                     result = populate(clazz, subEntityMetadata, rowId, subEntityMetadata.getRelationNames(), metaModel);
-                    if (result != null && !result.isEmpty())
-                    {
+                    if (result != null && !result.isEmpty()) {
                         break;
                     }
                 }
-            }
-            else
-            {
+            } else {
                 result = populate(clazz, metadata, rowId, relationNames, metaModel);
             }
-        }
-        catch (Exception e)
-        {
+        } catch (Exception e) {
             log.error("Error while retrieving records from database for entity {} and key {}, Caused by: .", clazz,
-                    rowId, e);
+                rowId, e);
 
             throw new PersistenceException(e);
         }
@@ -782,51 +704,42 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      * @return the list
      */
     private List<Object> populate(Class<?> clazz, EntityMetadata metadata, Object rowId, List<String> relationNames,
-            MetamodelImpl metaModel)
-    {
+        MetamodelImpl metaModel) {
         List<Object> result;
-        if (isCql3Enabled(metadata))
-        {
+        if (isCql3Enabled(metadata)) {
             result = cqlClient.find(metaModel, metadata, rowId, relationNames);
-        }
-        else
-        {
+        } else {
             result = (List<Object>) find(clazz, relationNames, relationNames != null, metadata, rowId);
         }
         return result;
     }
 
     /**
-     * Returns true in case of, composite Id and if cql3 opted and not a
-     * embedded entity.
+     * Returns true in case of, composite Id and if cql3 opted and not a embedded entity.
      * 
      * @param metadata
      *            the metadata
      * @return true, if is cql3 enabled
      */
-    public boolean isCql3Enabled(EntityMetadata metadata)
-    {
-        if (metadata != null)
-        {
+    public boolean isCql3Enabled(EntityMetadata metadata) {
+        if (metadata != null) {
 
-            MetamodelImpl metaModel = (MetamodelImpl) kunderaMetadata.getApplicationMetadata().getMetamodel(
-                    metadata.getPersistenceUnit());
+            MetamodelImpl metaModel =
+                (MetamodelImpl) kunderaMetadata.getApplicationMetadata().getMetamodel(metadata.getPersistenceUnit());
 
-            if (metaModel.isEmbeddable(metadata.getIdAttribute().getBindableJavaType()))
-            {
+            if (metaModel.isEmbeddable(metadata.getIdAttribute().getBindableJavaType())) {
                 return true;
             }
             // added for embeddables support on cql3
             AbstractManagedType managedType = (AbstractManagedType) metaModel.entity(metadata.getEntityClazz());
-            if (managedType.hasEmbeddableAttribute())
-            {
+            if (managedType.hasEmbeddableAttribute()) {
                 return getCqlVersion().equalsIgnoreCase(CassandraConstants.CQL_VERSION_3_0);
             }
 
             if (getCqlVersion().equalsIgnoreCase(CassandraConstants.CQL_VERSION_3_0)
-                    && metadata.getType().equals(Type.SUPER_COLUMN_FAMILY))
-            {
-                log.warn("Super Columns not supported by cql, Any operation on supercolumn family will be executed using thrift, returning false.");
+                && metadata.getType().equals(Type.SUPER_COLUMN_FAMILY)) {
+                log.warn(
+                    "Super Columns not supported by cql, Any operation on supercolumn family will be executed using thrift, returning false.");
                 return false;
             }
             return getCqlVersion().equalsIgnoreCase(CassandraConstants.CQL_VERSION_3_0);
@@ -835,13 +748,11 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
     }
 
     /**
-     * Returns true in case of, composite Id and if cql3 opted and not a
-     * embedded entity.
+     * Returns true in case of, composite Id and if cql3 opted and not a embedded entity.
      * 
      * @return true, if is cql3 enabled
      */
-    public boolean isCql3Enabled()
-    {
+    public boolean isCql3Enabled() {
         return isCql3Enabled(null);
     }
 
@@ -858,33 +769,28 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      *            the data handler
      * @return the list
      */
-    public <E> List<E> find(Class<E> entityClass, Map<String, String> superColumnMap, CassandraDataHandler dataHandler)
-    {
+    public <E> List<E> find(Class<E> entityClass, Map<String, String> superColumnMap,
+        CassandraDataHandler dataHandler) {
         List<E> entities = null;
         String entityId = null;
-        try
-        {
-            EntityMetadata entityMetadata = KunderaMetadataManager.getEntityMetadata(kunderaMetadata,
-                    getPersistenceUnit(), entityClass);
+        try {
+            EntityMetadata entityMetadata =
+                KunderaMetadataManager.getEntityMetadata(kunderaMetadata, getPersistenceUnit(), entityClass);
             entities = new ArrayList<E>();
-            for (String superColumnName : superColumnMap.keySet())
-            {
+            for (String superColumnName : superColumnMap.keySet()) {
                 entityId = superColumnMap.get(superColumnName);
-                List<SuperColumn> superColumnList = loadSuperColumns(entityMetadata.getSchema(),
-                        entityMetadata.getTableName(), entityId,
+                List<SuperColumn> superColumnList =
+                    loadSuperColumns(entityMetadata.getSchema(), entityMetadata.getTableName(), entityId,
                         new String[] { superColumnName.substring(0, superColumnName.indexOf("|")) });
                 E e = (E) dataHandler.fromThriftRow(entityMetadata.getEntityClazz(), entityMetadata,
-                        new DataRow<SuperColumn>(entityId, entityMetadata.getTableName(), superColumnList));
-                if (e != null)
-                {
+                    new DataRow<SuperColumn>(entityId, entityMetadata.getTableName(), superColumnList));
+                if (e != null) {
                     entities.add(e);
                 }
             }
-        }
-        catch (Exception e)
-        {
+        } catch (Exception e) {
             log.error("Error while retrieving records from database for entity {} and key {}, Caused by: . ",
-                    entityClass, entityId, e);
+                entityClass, entityId, e);
             throw new KunderaException(e);
         }
         return entities;
@@ -906,10 +812,8 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      * @return the list
      */
     public List executeSelectQuery(Class clazz, List<String> relationalField, CassandraDataHandler dataHandler,
-            boolean isNative, String cqlQuery)
-    {
-        if (log.isDebugEnabled())
-        {
+        boolean isNative, String cqlQuery) {
+        if (log.isDebugEnabled()) {
             log.debug("Executing cql query {}.", cqlQuery);
         }
 
@@ -917,26 +821,22 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
 
         EntityMetadata entityMetadata = KunderaMetadataManager.getEntityMetadata(kunderaMetadata, clazz);
 
-        MetamodelImpl metaModel = (MetamodelImpl) kunderaMetadata.getApplicationMetadata().getMetamodel(
-                entityMetadata.getPersistenceUnit());
+        MetamodelImpl metaModel =
+            (MetamodelImpl) kunderaMetadata.getApplicationMetadata().getMetamodel(entityMetadata.getPersistenceUnit());
 
         EntityType entityType = metaModel.entity(entityMetadata.getEntityClazz());
 
         List<AbstractManagedType> subManagedType = ((AbstractManagedType) entityType).getSubManagedType();
 
-        if (subManagedType.isEmpty())
-        {
+        if (subManagedType.isEmpty()) {
             entities.addAll(cqlClient.executeQuery(clazz, relationalField, dataHandler, true, isNative, cqlQuery));
-        }
-        else
-        {
-            for (AbstractManagedType subEntity : subManagedType)
-            {
-                EntityMetadata subEntityMetadata = KunderaMetadataManager.getEntityMetadata(kunderaMetadata,
-                        subEntity.getJavaType());
+        } else {
+            for (AbstractManagedType subEntity : subManagedType) {
+                EntityMetadata subEntityMetadata =
+                    KunderaMetadataManager.getEntityMetadata(kunderaMetadata, subEntity.getJavaType());
 
-                entities.addAll(cqlClient.executeQuery(subEntityMetadata.getEntityClazz(), relationalField,
-                        dataHandler, true, isNative, cqlQuery));
+                entities.addAll(cqlClient.executeQuery(subEntityMetadata.getEntityClazz(), relationalField, dataHandler,
+                    true, isNative, cqlQuery));
             }
         }
         return entities;
@@ -949,51 +849,39 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      *            the cql query
      * @return the list
      */
-    public List executeScalarQuery(String cqlQuery)
-    {
+    public List executeScalarQuery(String cqlQuery) {
         CqlResult cqlResult = null;
         List results = new ArrayList();
-        try
-        {
-            if (log.isDebugEnabled())
-            {
+        try {
+            if (log.isDebugEnabled()) {
                 log.debug("Executing query {}.", cqlQuery);
             }
             cqlResult = (CqlResult) executeCQLQuery(cqlQuery, true);
 
-            if (cqlResult != null && (cqlResult.getRows() != null || cqlResult.getRowsSize() > 0))
-            {
+            if (cqlResult != null && (cqlResult.getRows() != null || cqlResult.getRowsSize() > 0)) {
                 results = new ArrayList<Object>(cqlResult.getRowsSize());
                 Iterator<CqlRow> iter = cqlResult.getRowsIterator();
-                while (iter.hasNext())
-                {
+                while (iter.hasNext()) {
                     Map<String, Object> entity = new HashMap<String, Object>();
 
                     CqlRow row = iter.next();
-                    for (Column column : row.getColumns())
-                    {
-                        if (column != null)
-                        {
-                            String thriftColumnName = PropertyAccessorFactory.STRING.fromBytes(String.class,
-                                    column.getName());
+                    for (Column column : row.getColumns()) {
+                        if (column != null) {
+                            String thriftColumnName =
+                                PropertyAccessorFactory.STRING.fromBytes(String.class, column.getName());
 
-                            if (column.getValue() == null)
-                            {
+                            if (column.getValue() == null) {
                                 entity.put(thriftColumnName, null);
-                            }
-                            else
-                            {
+                            } else {
                                 entity.put(thriftColumnName,
-                                        composeColumnValue(cqlResult.getSchema(), column.getValue(), column.getName()));
+                                    composeColumnValue(cqlResult.getSchema(), column.getValue(), column.getName()));
                             }
                         }
                     }
                     results.add(entity);
                 }
             }
-        }
-        catch (Exception e)
-        {
+        } catch (Exception e) {
             log.error("Error while executing native CQL query Caused by {}.", e);
             throw new PersistenceException(e);
         }
@@ -1011,21 +899,18 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      *            the thrift column name
      * @return the object
      */
-    private Object composeColumnValue(CqlMetadata cqlMetadata, byte[] thriftColumnValue, byte[] thriftColumnName)
-    {
+    private Object composeColumnValue(CqlMetadata cqlMetadata, byte[] thriftColumnValue, byte[] thriftColumnName) {
         Map<ByteBuffer, String> schemaTypes = cqlMetadata.getValue_types();
         AbstractType<?> type = null;
-        try
-        {
+        try {
             type = TypeParser.parse(schemaTypes.get(ByteBuffer.wrap(thriftColumnName)));
-        }
-        catch (SyntaxException | ConfigurationException ex)
-        {
+        } catch (SyntaxException | ConfigurationException ex) {
             log.error(ex.getMessage());
             throw new KunderaException("Error while deserializing column value " + ex);
         }
-        if(type.isCollection()){
-            return ((CollectionSerializer) type.getSerializer()).deserializeForNativeProtocol(ByteBuffer.wrap(thriftColumnValue), ProtocolVersion.V2);
+        if (type.isCollection()) {
+            return ((CollectionSerializer) type.getSerializer())
+                .deserializeForNativeProtocol(ByteBuffer.wrap(thriftColumnValue), ProtocolVersion.V2);
         }
         return type.compose(ByteBuffer.wrap(thriftColumnValue));
     }
@@ -1037,19 +922,14 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      *            the cql query
      * @return the int
      */
-    public int executeUpdateDeleteQuery(String cqlQuery)
-    {
-        if (log.isDebugEnabled())
-        {
+    public int executeUpdateDeleteQuery(String cqlQuery) {
+        if (log.isDebugEnabled()) {
             log.debug("Executing cql query {}.", cqlQuery);
         }
-        try
-        {
+        try {
             CqlResult result = (CqlResult) executeCQLQuery(cqlQuery, true);
             return result.getNum();
-        }
-        catch (Exception e)
-        {
+        } catch (Exception e) {
             log.error("Error while executing updated query: {}, Caused by: . ", cqlQuery, e);
             return 0;
         }
@@ -1061,8 +941,7 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      * 
      * @return the external properties
      */
-    public Map<String, Object> getExternalProperties()
-    {
+    public Map<String, Object> getExternalProperties() {
         return externalProperties;
     }
 
@@ -1084,18 +963,16 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      *             the exception
      */
     protected List populateEntitiesFromKeySlices(EntityMetadata m, boolean isWrapReq, List<String> relations,
-            List<KeySlice> keys, CassandraDataHandler dataHandler) throws Exception
-    {
+        List<KeySlice> keys, CassandraDataHandler dataHandler) throws Exception {
         List results;
-        MetamodelImpl metaModel = (MetamodelImpl) kunderaMetadata.getApplicationMetadata().getMetamodel(
-                m.getPersistenceUnit());
+        MetamodelImpl metaModel =
+            (MetamodelImpl) kunderaMetadata.getApplicationMetadata().getMetamodel(m.getPersistenceUnit());
 
         Set<String> superColumnAttribs = metaModel.getEmbeddables(m.getEntityClazz()).keySet();
         results = new ArrayList(keys.size());
 
         ThriftDataResultHelper dataGenerator = new ThriftDataResultHelper();
-        for (KeySlice key : keys)
-        {
+        for (KeySlice key : keys) {
             List<ColumnOrSuperColumn> columns = key.getColumns();
 
             byte[] rowKey = key.getKey();
@@ -1112,8 +989,7 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
 
             e = dataHandler.populateEntity(tr, m, KunderaCoreUtils.getEntity(e), relations, isWrapReq);
 
-            if (e != null)
-            {
+            if (e != null) {
                 results.add(e);
             }
         }
@@ -1136,55 +1012,49 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      * @return the list
      */
     protected List<String> createInsertQuery(EntityMetadata entityMetadata, Object entity,
-            Cassandra.Client cassandra_client, List<RelationHolder> rlHolders, Object ttlColumns)
-    {
+        Cassandra.Client cassandra_client, List<RelationHolder> rlHolders, Object ttlColumns) {
         List<String> insert_Queries = new ArrayList<String>();
         CQLTranslator translator = new CQLTranslator();
         HashMap<TranslationType, Map<String, StringBuilder>> translation = translator.prepareColumnOrColumnValues(
-                entity, entityMetadata, TranslationType.ALL, externalProperties, kunderaMetadata);
+            entity, entityMetadata, TranslationType.ALL, externalProperties, kunderaMetadata);
 
         Map<String, StringBuilder> columnNamesMap = translation.get(TranslationType.COLUMN);
         Map<String, StringBuilder> columnValuesMap = translation.get(TranslationType.VALUE);
 
-        for (String tableName : columnNamesMap.keySet())
-        {
+        for (String tableName : columnNamesMap.keySet()) {
             String insert_Query = translator.INSERT_QUERY;
 
             insert_Query = StringUtils.replace(insert_Query, CQLTranslator.COLUMN_FAMILY,
-                    translator.ensureCase(new StringBuilder(), tableName, false).toString());
+                translator.ensureCase(new StringBuilder(), tableName, false).toString());
             String columnNames = columnNamesMap.get(tableName).toString();
             String columnValues = columnValuesMap.get(tableName).toString();
 
             StringBuilder columnNameBuilder = new StringBuilder(columnNames);
             StringBuilder columnValueBuilder = new StringBuilder(columnValues);
 
-            for (RelationHolder rl : rlHolders)
-            {
-                columnValueBuilder = onRelationColumns(columnNames, columnValues, columnNameBuilder,
-                        columnValueBuilder, rl);
+            for (RelationHolder rl : rlHolders) {
+                columnValueBuilder =
+                    onRelationColumns(columnNames, columnValues, columnNameBuilder, columnValueBuilder, rl);
 
                 columnNameBuilder.append(",");
                 columnValueBuilder.append(",");
                 translator.appendColumnName(columnNameBuilder, rl.getRelationName());
                 translator.appendValue(columnValueBuilder, rl.getRelationValue().getClass(), rl.getRelationValue(),
-                        true, false);
+                    true, false);
 
             }
 
-            insert_Query = StringUtils
-                    .replace(insert_Query, CQLTranslator.COLUMN_VALUES, columnValueBuilder.toString());
+            insert_Query =
+                StringUtils.replace(insert_Query, CQLTranslator.COLUMN_VALUES, columnValueBuilder.toString());
             insert_Query = StringUtils.replace(insert_Query, CQLTranslator.COLUMNS, columnNameBuilder.toString());
 
-            if (log.isDebugEnabled())
-            {
+            if (log.isDebugEnabled()) {
                 log.debug("Returning cql query {}.", insert_Query);
             }
 
-            if (ttlColumns != null && ttlColumns instanceof Integer)
-            {
+            if (ttlColumns != null && ttlColumns instanceof Integer) {
                 int ttl = ((Integer) ttlColumns).intValue();
-                if (ttl != 0)
-                {
+                if (ttl != 0) {
                     insert_Query = insert_Query + " USING TTL " + ttl;
                 }
             }
@@ -1209,22 +1079,19 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      * @return To remove redundant columns in insert query
      */
     private StringBuilder onRelationColumns(String columnNames, String columnValues, StringBuilder columnNameBuilder,
-            StringBuilder columnValueBuilder, RelationHolder rl)
-    {
+        StringBuilder columnValueBuilder, RelationHolder rl) {
         int relnameIndx = columnNameBuilder.indexOf("\"" + rl.getRelationName() + "\"");
-        if (relnameIndx != -1 && rl.getRelationValue() != null)
-        {
+        if (relnameIndx != -1 && rl.getRelationValue() != null) {
 
             List<String> cNameArray = Arrays.asList(columnNames.split(","));
             List<String> cValueArray = new ArrayList<String>(Arrays.asList(columnValues.split(",")));
             int cValueIndex = cNameArray.indexOf("\"" + rl.getRelationName() + "\"");
 
-            if (cValueArray.get(cValueIndex).equals("null"))
-            {
+            if (cValueArray.get(cValueIndex).equals("null")) {
                 columnNameBuilder.delete(relnameIndx - 1, relnameIndx + rl.getRelationName().length() + 2);
                 cValueArray.remove(cValueIndex);
-                columnValueBuilder = new StringBuilder(cValueArray.toString().substring(1,
-                        cValueArray.toString().length() - 1));
+                columnValueBuilder =
+                    new StringBuilder(cValueArray.toString().substring(1, cValueArray.toString().length() - 1));
 
             }
 
@@ -1233,8 +1100,7 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
     }
 
     /**
-     * Return update query string for given entity intended for counter column
-     * family.
+     * Return update query string for given entity intended for counter column family.
      * 
      * @param entityMetadata
      *            the entity metadata
@@ -1247,57 +1113,49 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      * @return the list
      */
     protected List<String> createUpdateQueryForCounter(EntityMetadata entityMetadata, Object entity,
-            Cassandra.Client cassandra_client, List<RelationHolder> rlHolders)
-    {
+        Cassandra.Client cassandra_client, List<RelationHolder> rlHolders) {
         Map<String, String> builders = new HashMap<String, String>();
 
         CQLTranslator translator = new CQLTranslator();
 
         Object rowId = PropertyAccessorHelper.getId(entity, entityMetadata);
-        MetamodelImpl metaModel = (MetamodelImpl) kunderaMetadata.getApplicationMetadata().getMetamodel(
-                entityMetadata.getPersistenceUnit());
+        MetamodelImpl metaModel =
+            (MetamodelImpl) kunderaMetadata.getApplicationMetadata().getMetamodel(entityMetadata.getPersistenceUnit());
 
         EntityType entityType = metaModel.entity(entityMetadata.getEntityClazz());
 
         Set<Attribute> attributes = entityType.getAttributes();
 
-        for (Attribute attrib : attributes)
-        {
+        for (Attribute attrib : attributes) {
             if (!entityMetadata.getIdAttribute().getName().equals(attrib.getName())
-                    && !metaModel.isEmbeddable(attrib.getJavaType()) && !attrib.isAssociation())
-            {
-                String tableName = ((AbstractAttribute) attrib).getTableName() != null ? ((AbstractAttribute) attrib)
-                        .getTableName() : entityMetadata.getTableName();
+                && !metaModel.isEmbeddable(attrib.getJavaType()) && !attrib.isAssociation()) {
+                String tableName = ((AbstractAttribute) attrib).getTableName() != null
+                    ? ((AbstractAttribute) attrib).getTableName() : entityMetadata.getTableName();
 
                 String queryString = builders.get(tableName);
                 StringBuilder builder;
-                if (queryString == null)
-                {
+                if (queryString == null) {
                     builder = new StringBuilder();
-                }
-                else
-                {
+                } else {
                     builder = new StringBuilder(queryString);
                 }
                 translator.buildSetClauseForCounters(builder, ((AbstractAttribute) attrib).getJPAColumnName(),
-                        PropertyAccessorHelper.getObject(entity, attrib.getName()));
+                    PropertyAccessorHelper.getObject(entity, attrib.getName()));
                 builders.put(tableName, builder.toString());
             }
         }
-        for (RelationHolder rl : rlHolders)
-        {
+        for (RelationHolder rl : rlHolders) {
             translator.buildSetClauseForCounters(new StringBuilder(builders.get(entityMetadata.getTableName())),
-                    rl.getRelationName(), rl.getRelationValue());
+                rl.getRelationName(), rl.getRelationValue());
         }
 
-        for (String tableName : builders.keySet())
-        {
+        for (String tableName : builders.keySet()) {
             StringBuilder builder = new StringBuilder(builders.get(tableName));
 
             String update_Query = translator.UPDATE_QUERY;
 
             update_Query = StringUtils.replace(update_Query, CQLTranslator.COLUMN_FAMILY,
-                    translator.ensureCase(new StringBuilder(), tableName, false).toString());
+                translator.ensureCase(new StringBuilder(), tableName, false).toString());
 
             // strip last "," clause.
             builder.delete(builder.lastIndexOf(CQLTranslator.COMMA_STR), builder.length());
@@ -1312,8 +1170,7 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
             queryBuilder.append(CQLTranslator.ADD_SET_CLAUSE);
             queryBuilder.append(builder);
 
-            if (log.isDebugEnabled())
-            {
+            if (log.isDebugEnabled()) {
                 log.debug("Returning update query {}.", queryBuilder.toString());
             }
 
@@ -1338,15 +1195,11 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      * @return the persist queries
      */
     protected List<String> getPersistQueries(EntityMetadata entityMetadata, Object entity,
-            org.apache.cassandra.thrift.Cassandra.Client conn, List<RelationHolder> rlHolders, Object ttlColumns)
-    {
+        org.apache.cassandra.thrift.Cassandra.Client conn, List<RelationHolder> rlHolders, Object ttlColumns) {
         List<String> queries;
-        if (entityMetadata.isCounterColumnType())
-        {
+        if (entityMetadata.isCounterColumnType()) {
             queries = createUpdateQueryForCounter(entityMetadata, entity, conn, rlHolders);
-        }
-        else
-        {
+        } else {
             queries = createInsertQuery(entityMetadata, entity, conn, rlHolders, ttlColumns);
         }
         return queries;
@@ -1357,8 +1210,7 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      * 
      * @return the cqlVersion
      */
-    protected String getCqlVersion()
-    {
+    protected String getCqlVersion() {
         return this.cqlVersion;
     }
 
@@ -1368,8 +1220,7 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      * @param cqlVersion
      *            the cqlVersion to set
      */
-    public void setCqlVersion(String cqlVersion)
-    {
+    public void setCqlVersion(String cqlVersion) {
         this.cqlVersion = cqlVersion;
     }
 
@@ -1379,14 +1230,10 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      * @param cLevel
      *            the new consistency level
      */
-    public void setConsistencyLevel(ConsistencyLevel cLevel)
-    {
-        if (cLevel != null)
-        {
+    public void setConsistencyLevel(ConsistencyLevel cLevel) {
+        if (cLevel != null) {
             this.consistencyLevel = cLevel;
-        }
-        else
-        {
+        } else {
             log.warn("Invalid consistency level {null} provided, default level will be used.");
         }
     }
@@ -1394,8 +1241,7 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
     /**
      * Close.
      */
-    public void close()
-    {
+    public void close() {
         clear();
         setCqlVersion(CassandraConstants.CQL_VERSION_2_0);
         closed = true;
@@ -1407,8 +1253,7 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      * 
      * @return true, if is open
      */
-    protected final boolean isOpen()
-    {
+    protected final boolean isOpen() {
         return !closed;
     }
 
@@ -1417,8 +1262,7 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      * 
      * @return the consistency level
      */
-    public ConsistencyLevel getConsistencyLevel()
-    {
+    public ConsistencyLevel getConsistencyLevel() {
         return consistencyLevel;
     }
 
@@ -1435,13 +1279,13 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      *            the compound key object
      * @return the string
      */
-    protected String onDeleteQuery(EntityMetadata metadata, String tableName, MetamodelImpl metaModel, Object keyObject)
-    {
+    protected String onDeleteQuery(EntityMetadata metadata, String tableName, MetamodelImpl metaModel,
+        Object keyObject) {
         CQLTranslator translator = new CQLTranslator();
         String deleteQuery = CQLTranslator.DELETE_QUERY;
 
         deleteQuery = StringUtils.replace(deleteQuery, CQLTranslator.COLUMN_FAMILY,
-                translator.ensureCase(new StringBuilder(), tableName, false).toString());
+            translator.ensureCase(new StringBuilder(), tableName, false).toString());
 
         StringBuilder deleteQueryBuilder = new StringBuilder(deleteQuery);
 
@@ -1449,11 +1293,10 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
         onWhereClause(metadata, keyObject, translator, deleteQueryBuilder, metaModel, metadata.getIdAttribute());
 
         // strip last "AND" clause.
-        deleteQueryBuilder
-                .delete(deleteQueryBuilder.lastIndexOf(CQLTranslator.AND_CLAUSE), deleteQueryBuilder.length());
+        deleteQueryBuilder.delete(deleteQueryBuilder.lastIndexOf(CQLTranslator.AND_CLAUSE),
+            deleteQueryBuilder.length());
 
-        if (log.isDebugEnabled())
-        {
+        if (log.isDebugEnabled()) {
             log.debug("Returning delete query {}.", deleteQueryBuilder.toString());
         }
         return deleteQueryBuilder.toString();
@@ -1476,39 +1319,31 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      *            the attribute
      */
     protected void onWhereClause(EntityMetadata metadata, Object key, CQLTranslator translator,
-            StringBuilder queryBuilder, MetamodelImpl metaModel, SingularAttribute attribute)
-    {
+        StringBuilder queryBuilder, MetamodelImpl metaModel, SingularAttribute attribute) {
         // SingularAttribute idAttribute = metadata.getIdAttribute();
-        if (metaModel.isEmbeddable(attribute.getBindableJavaType()))
-        {
+        if (metaModel.isEmbeddable(attribute.getBindableJavaType())) {
             Field[] fields = attribute.getBindableJavaType().getDeclaredFields();
             EmbeddableType compoundKey = metaModel.embeddable(attribute.getBindableJavaType());
 
-            for (Field field : fields)
-            {
+            for (Field field : fields) {
                 if (field != null && !Modifier.isStatic(field.getModifiers())
-                        && !Modifier.isTransient(field.getModifiers()) && !field.isAnnotationPresent(Transient.class))
-                {
+                    && !Modifier.isTransient(field.getModifiers()) && !field.isAnnotationPresent(Transient.class)) {
                     attribute = (SingularAttribute) compoundKey.getAttribute(field.getName());
                     Object valueObject = PropertyAccessorHelper.getObject(key, field);
-                    if (metaModel.isEmbeddable(((AbstractAttribute) attribute).getBindableJavaType()))
-                    {
+                    if (metaModel.isEmbeddable(((AbstractAttribute) attribute).getBindableJavaType())) {
                         onWhereClause(metadata, valueObject, translator, queryBuilder, metaModel, attribute);
-                    }
-                    else
-                    {
+                    } else {
                         String columnName = ((AbstractAttribute) attribute).getJPAColumnName();
                         translator.buildWhereClause(queryBuilder, field.getType(), columnName, valueObject,
-                                CQLTranslator.EQ_CLAUSE, false);
+                            CQLTranslator.EQ_CLAUSE, false);
                     }
                 }
             }
-        }
-        else
-        {
-            translator.buildWhereClause(queryBuilder, ((AbstractAttribute) attribute).getBindableJavaType(),
-                    CassandraUtilities.getIdColumnName(kunderaMetadata, metadata, getExternalProperties(),
-                            isCql3Enabled(metadata)), key, translator.EQ_CLAUSE, false);
+        } else {
+            translator.buildWhereClause(
+                queryBuilder, ((AbstractAttribute) attribute).getBindableJavaType(), CassandraUtilities
+                    .getIdColumnName(kunderaMetadata, metadata, getExternalProperties(), isCql3Enabled(metadata)),
+                key, translator.EQ_CLAUSE, false);
         }
     }
 
@@ -1527,8 +1362,8 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      *            the row ids
      * @return the list
      */
-    public abstract List find(Class entityClass, List<String> relationNames, boolean isWrapReq,
-            EntityMetadata metadata, Object... rowIds);
+    public abstract List find(Class entityClass, List<String> relationNames, boolean isWrapReq, EntityMetadata metadata,
+        Object... rowIds);
 
     /**
      * Load super columns.
@@ -1544,7 +1379,7 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      * @return the list
      */
     protected abstract List<SuperColumn> loadSuperColumns(String keyspace, String columnFamily, String rowId,
-            String... superColumnNames);
+        String... superColumnNames);
 
     /**
      * Query related methods.
@@ -1562,14 +1397,9 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
     public abstract List executeQuery(Class clazz, List<String> relationalField, boolean isNative, String cqlQuery);
 
     // XXX
-    public List executeQuery(
-	Class clazz,
-	List<String> relationalField,
-	boolean isNative,
-	String cqlQuery,
-	final List<KunderaQuery.BindParameter> parameters
-    ) {
-            throw new KunderaException("not implemented");
+    public List executeQuery(Class clazz, List<String> relationalField, boolean isNative, String cqlQuery,
+        final List<KunderaQuery.BindParameter> parameters) {
+        throw new KunderaException("not implemented");
     }
 
     /**
@@ -1590,7 +1420,7 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      * @return the list
      */
     public abstract List find(List<IndexClause> ixClause, EntityMetadata m, boolean isRelation, List<String> relations,
-            int maxResult, List<String> columns);
+        int maxResult, List<String> columns);
 
     /**
      * Find by range.
@@ -1616,8 +1446,8 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      *             the exception
      */
     public abstract List findByRange(byte[] muinVal, byte[] maxVal, EntityMetadata m, boolean isWrapReq,
-            List<String> relations, List<String> columns, List<IndexExpression> conditions, int maxResults)
-            throws Exception;
+        List<String> relations, List<String> columns, List<IndexExpression> conditions, int maxResults)
+        throws Exception;
 
     /**
      * Search in inverted index.
@@ -1631,7 +1461,7 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      * @return the list
      */
     public abstract List<SearchResult> searchInInvertedIndex(String columnFamilyName, EntityMetadata m,
-            Map<Boolean, List<IndexClause>> indexClauseMap);
+        Map<Boolean, List<IndexClause>> indexClauseMap);
 
     /**
      * Find.
@@ -1648,8 +1478,8 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      *            the columns
      * @return the list
      */
-    public abstract List<EnhanceEntity> find(EntityMetadata m, List<String> relationNames,
-            List<IndexClause> conditions, int maxResult, List<String> columns);
+    public abstract List<EnhanceEntity> find(EntityMetadata m, List<String> relationNames, List<IndexClause> conditions,
+        int maxResult, List<String> columns);
 
     /**
      * Gets the data handler.
@@ -1671,9 +1501,7 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
     /*
      * (non-Javadoc)
      * 
-     * @see
-     * com.impetus.kundera.persistence.api.Batcher#addBatch(com.impetus.kundera
-     * .graph.Node)
+     * @see com.impetus.kundera.persistence.api.Batcher#addBatch(com.impetus.kundera .graph.Node)
      */
     /**
      * Adds the batch.
@@ -1681,11 +1509,9 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      * @param node
      *            the node
      */
-    public void addBatch(Node node)
-    {
+    public void addBatch(Node node) {
 
-        if (node != null)
-        {
+        if (node != null) {
             nodes.add(node);
         }
 
@@ -1702,8 +1528,7 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      * 
      * @return the batch size
      */
-    public int getBatchSize()
-    {
+    public int getBatchSize() {
         return batchSize;
     }
 
@@ -1715,16 +1540,13 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
     /**
      * Clear.
      */
-    public void clear()
-    {
-        if (nodes != null)
-        {
+    public void clear() {
+        if (nodes != null) {
             nodes.clear();
             nodes = new ArrayList<Node>();
         }
 
-        if (ttlPerSession)
-        {
+        if (ttlPerSession) {
             ttlValues.clear();
         }
     }
@@ -1739,89 +1561,72 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      * 
      * @return the int
      */
-    public int executeBatch()
-    {
+    public int executeBatch() {
         Cassandra.Client conn = null;
         Object pooledConnection = null;
 
         /**
-         * Key -> Entity Class Value -> Map containing Row ID as Key and
-         * Mutation List as Value
+         * Key -> Entity Class Value -> Map containing Row ID as Key and Mutation List as Value
          */
-        Map<Class<?>, Map<ByteBuffer, Map<String, List<Mutation>>>> batchMutationMap = new HashMap<Class<?>, Map<ByteBuffer, Map<String, List<Mutation>>>>();
+        Map<Class<?>, Map<ByteBuffer, Map<String, List<Mutation>>>> batchMutationMap =
+            new HashMap<Class<?>, Map<ByteBuffer, Map<String, List<Mutation>>>>();
 
         int recordsExecuted = 0;
         boolean setCounter = true;
         String batchQuery = CQLTranslator.BATCH_QUERY;
         batchQuery = StringUtils.replace(batchQuery, CQLTranslator.STATEMENT, "");
         StringBuilder batchQueryBuilder = new StringBuilder(batchQuery);
-        try
-        {
+        try {
             boolean isCql3Enabled = false;
-            for (Node node : nodes)
-            {
-                if (node.isDirty())
-                {
+            for (Node node : nodes) {
+                if (node.isDirty()) {
                     node.handlePreEvent();
                     Object entity = node.getData();
                     Object id = node.getEntityId();
-                    EntityMetadata metadata = KunderaMetadataManager.getEntityMetadata(kunderaMetadata,
-                            node.getDataClass());
-                    if (metadata.isCounterColumnType() && setCounter)
-                    {
+                    EntityMetadata metadata =
+                        KunderaMetadataManager.getEntityMetadata(kunderaMetadata, node.getDataClass());
+                    if (metadata.isCounterColumnType() && setCounter) {
                         batchQueryBuilder = new StringBuilder(StringUtils.replace(batchQueryBuilder.toString(),
-                                CQLTranslator.BEGIN_BATCH, CQLTranslator.BEGIN_COUNTER_BATCH));
+                            CQLTranslator.BEGIN_BATCH, CQLTranslator.BEGIN_COUNTER_BATCH));
                         setCounter = false;
                     }
                     persistenceUnit = metadata.getPersistenceUnit();
                     isUpdate = node.isUpdate();
 
-                    MetamodelImpl metaModel = (MetamodelImpl) kunderaMetadata.getApplicationMetadata().getMetamodel(
-                            metadata.getPersistenceUnit());
+                    MetamodelImpl metaModel = (MetamodelImpl) kunderaMetadata.getApplicationMetadata()
+                        .getMetamodel(metadata.getPersistenceUnit());
 
                     // delete can not be executed in batch
 
-                    if (isCql3Enabled(metadata))
-                    {
+                    if (isCql3Enabled(metadata)) {
                         isCql3Enabled = true;
                         List<RelationHolder> relationHolders = getRelationHolders(node);
-                        if (node.isInState(RemovedState.class))
-                        {
+                        if (node.isInState(RemovedState.class)) {
                             String query;
                             query = onDeleteQuery(metadata, metadata.getTableName(), metaModel, id);
                             batchQueryBuilder.append(Constants.SPACE);
                             batchQueryBuilder.append(query);
-                        }
-                        else
-                        {
+                        } else {
                             List<String> insertQueries = getPersistQueries(metadata, entity, conn, relationHolders,
-                                    getTtlValues().get(metadata.getTableName()));
-                            for (String query : insertQueries)
-                            {
+                                getTtlValues().get(metadata.getTableName()));
+                            for (String query : insertQueries) {
                                 batchQueryBuilder.append(Constants.SPACE);
                                 batchQueryBuilder.append(query);
                             }
                         }
-                    }
-                    else
-                    {
-                        if (node.isInState(RemovedState.class))
-                        {
+                    } else {
+                        if (node.isInState(RemovedState.class)) {
                             delete(entity, id);
-                        }
-                        else
-                        {
+                        } else {
                             List<RelationHolder> relationHolders = getRelationHolders(node);
-                            Map<ByteBuffer, Map<String, List<Mutation>>> mutationMap = new HashMap<ByteBuffer, Map<String, List<Mutation>>>();
+                            Map<ByteBuffer, Map<String, List<Mutation>>> mutationMap =
+                                new HashMap<ByteBuffer, Map<String, List<Mutation>>>();
                             mutationMap = prepareMutation(metadata, entity, id, relationHolders, mutationMap);
 
                             recordsExecuted += mutationMap.size();
-                            if (!batchMutationMap.containsKey(metadata.getEntityClazz()))
-                            {
+                            if (!batchMutationMap.containsKey(metadata.getEntityClazz())) {
                                 batchMutationMap.put(metadata.getEntityClazz(), mutationMap);
-                            }
-                            else
-                            {
+                            } else {
                                 batchMutationMap.get(metadata.getEntityClazz()).putAll(mutationMap);
                             }
 
@@ -1834,33 +1639,25 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
 
             // Write Mutation map to database
 
-            if (!batchMutationMap.isEmpty())
-            {
+            if (!batchMutationMap.isEmpty()) {
                 pooledConnection = getConnection();
                 conn = (org.apache.cassandra.thrift.Cassandra.Client) getConnection(pooledConnection);
 
-                for (Class<?> entityClass : batchMutationMap.keySet())
-                {
+                for (Class<?> entityClass : batchMutationMap.keySet()) {
                     conn.batch_mutate(batchMutationMap.get(entityClass), consistencyLevel);
                 }
             }
 
-            if (!nodes.isEmpty() && isCql3Enabled)
-            {
+            if (!nodes.isEmpty() && isCql3Enabled) {
                 batchQueryBuilder.append(CQLTranslator.APPLY_BATCH);
                 executeCQLQuery(batchQueryBuilder.toString(), isCql3Enabled);
             }
-        }
-        catch (Exception e)
-        {
+        } catch (Exception e) {
             log.error("Error while persisting record. Caused by: .", e);
             throw new KunderaException(e);
-        }
-        finally
-        {
+        } finally {
             clear();
-            if (pooledConnection != null)
-            {
+            if (pooledConnection != null) {
                 releaseConnection(pooledConnection);
             }
         }
@@ -1883,44 +1680,35 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      *            the mutation map
      * @return the map
      */
-    protected Map<ByteBuffer, Map<String, List<Mutation>>> prepareMutation(EntityMetadata entityMetadata,
-            Object entity, Object id, List<RelationHolder> relationHolders,
-            Map<ByteBuffer, Map<String, List<Mutation>>> mutationMap)
-    {
+    protected Map<ByteBuffer, Map<String, List<Mutation>>> prepareMutation(EntityMetadata entityMetadata, Object entity,
+        Object id, List<RelationHolder> relationHolders, Map<ByteBuffer, Map<String, List<Mutation>>> mutationMap) {
 
-        if (!isOpen())
-        {
+        if (!isOpen()) {
             throw new PersistenceException("ThriftClient is closed.");
         }
 
         // check for counter column
-        if (isUpdate && entityMetadata.isCounterColumnType())
-        {
+        if (isUpdate && entityMetadata.isCounterColumnType()) {
             log.warn("Invalid operation! {} is not possible over counter column of entity {}.", "Merge",
-                    entityMetadata.getEntityClazz());
+                entityMetadata.getEntityClazz());
             throw new UnsupportedOperationException("Invalid operation! Merge is not possible over counter column.");
         }
 
         Collection<ThriftRow> tfRows = null;
-        try
-        {
+        try {
             String columnFamily = entityMetadata.getTableName();
             tfRows = getDataHandler().toThriftRow(entity, id, entityMetadata, columnFamily,
-                    getTtlValues().get(columnFamily));
-        }
-        catch (Exception e)
-        {
+                getTtlValues().get(columnFamily));
+        } catch (Exception e) {
             log.error("Error during persisting record for entity {}, Caused by: .", entityMetadata.getEntityClazz(),
-                    entityMetadata.getTableName(), e);
+                entityMetadata.getTableName(), e);
             throw new KunderaException(e);
         }
 
         Map<String, List<Mutation>> columnFamilyValues = new HashMap<String, List<Mutation>>();
 
-        for (ThriftRow tf : tfRows)
-        {
-            if (tf.getColumnFamilyName().equals(entityMetadata.getTableName()))
-            {
+        for (ThriftRow tf : tfRows) {
+            if (tf.getColumnFamilyName().equals(entityMetadata.getTableName())) {
                 addRelationsToThriftRow(entityMetadata, tf, relationHolders);
             }
 
@@ -1930,42 +1718,34 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
 
             /*********** Handling for counter column family ************/
 
-            if (entityMetadata.isCounterColumnType())
-            {
+            if (entityMetadata.isCounterColumnType()) {
                 List<CounterColumn> thriftCounterColumns = tf.getCounterColumns();
                 List<CounterSuperColumn> thriftCounterSuperColumns = tf.getCounterSuperColumns();
 
-                if (thriftCounterColumns != null && !thriftCounterColumns.isEmpty())
-                {
-                    for (CounterColumn column : thriftCounterColumns)
-                    {
+                if (thriftCounterColumns != null && !thriftCounterColumns.isEmpty()) {
+                    for (CounterColumn column : thriftCounterColumns) {
                         Mutation mut = new Mutation();
                         mut.setColumn_or_supercolumn(new ColumnOrSuperColumn().setCounter_column(column));
                         mutationList.add(mut);
                     }
                 }
 
-                if (thriftCounterSuperColumns != null && !thriftCounterSuperColumns.isEmpty())
-                {
-                    for (CounterSuperColumn sc : thriftCounterSuperColumns)
-                    {
+                if (thriftCounterSuperColumns != null && !thriftCounterSuperColumns.isEmpty()) {
+                    for (CounterSuperColumn sc : thriftCounterSuperColumns) {
                         Mutation mut = new Mutation();
                         mut.setColumn_or_supercolumn(new ColumnOrSuperColumn().setCounter_super_column(sc));
                         mutationList.add(mut);
                     }
                 }
-            }
-            else
+            } else
             /********* Handling for column family and super column family *********/
             {
                 List<Column> thriftColumns = tf.getColumns();
                 List<SuperColumn> thriftSuperColumns = tf.getSuperColumns();
 
                 // Populate Insertion list for columns
-                if (thriftColumns != null && !thriftColumns.isEmpty())
-                {
-                    for (Column column : thriftColumns)
-                    {
+                if (thriftColumns != null && !thriftColumns.isEmpty()) {
+                    for (Column column : thriftColumns) {
                         Mutation mut = new Mutation();
                         mut.setColumn_or_supercolumn(new ColumnOrSuperColumn().setColumn(column));
                         mutationList.add(mut);
@@ -1973,10 +1753,8 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
                 }
 
                 // Populate Insertion list for super columns
-                if (thriftSuperColumns != null && !thriftSuperColumns.isEmpty())
-                {
-                    for (SuperColumn superColumn : thriftSuperColumns)
-                    {
+                if (thriftSuperColumns != null && !thriftSuperColumns.isEmpty()) {
+                    for (SuperColumn superColumn : thriftSuperColumns) {
                         Mutation mut = new Mutation();
                         mut.setColumn_or_supercolumn(new ColumnOrSuperColumn().setSuper_column(superColumn));
                         mutationList.add(mut);
@@ -1996,10 +1774,8 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
     /**
      * Check on batch limit.
      */
-    private void onBatchLimit()
-    {
-        if (batchSize > 0 && batchSize == nodes.size())
-        {
+    private void onBatchLimit() {
+        if (batchSize > 0 && batchSize == nodes.size()) {
             executeBatch();
             nodes.clear();
         }
@@ -2008,13 +1784,11 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
     /*
      * (non-Javadoc)
      * 
-     * @see
-     * com.impetus.kundera.client.ClientPropertiesSetter#populateClientProperties
+     * @see com.impetus.kundera.client.ClientPropertiesSetter#populateClientProperties
      * (com.impetus.kundera.client.Client, java.util.Map)
      */
     @Override
-    public void populateClientProperties(Client client, Map<String, Object> properties)
-    {
+    public void populateClientProperties(Client client, Map<String, Object> properties) {
         new CassandraClientProperties().populateClientProperties(client, properties);
     }
 
@@ -2025,23 +1799,17 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      *            schema or keyspace.
      * @return raw cassandra client.
      */
-    public Cassandra.Client getRawClient(final String schema)
-    {
+    public Cassandra.Client getRawClient(final String schema) {
         Cassandra.Client client = null;
         Object pooledConnection;
         pooledConnection = getConnection();
         client = (org.apache.cassandra.thrift.Cassandra.Client) getConnection(pooledConnection);
-        try
-        {
+        try {
             client.set_cql_version(getCqlVersion());
-        }
-        catch (Exception e)
-        {
+        } catch (Exception e) {
             log.error("Error during borrowing a connection , Caused by: {}.", e);
             throw new KunderaException(e);
-        }
-        finally
-        {
+        } finally {
             releaseConnection(pooledConnection);
         }
         return client;
@@ -2057,42 +1825,32 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      *            the is cql3 enabled
      * @return the object
      */
-    protected Object executeCQLQuery(String cqlQuery, boolean isCql3Enabled)
-    {
+    protected Object executeCQLQuery(String cqlQuery, boolean isCql3Enabled) {
         Cassandra.Client conn = null;
         Object pooledConnection = null;
         pooledConnection = getConnection();
         conn = (org.apache.cassandra.thrift.Cassandra.Client) getConnection(pooledConnection);
-        try
-        {
-            if (isCql3Enabled || isCql3Enabled())
-            {
+        try {
+            if (isCql3Enabled || isCql3Enabled()) {
                 return execute(cqlQuery, conn);
             }
             KunderaCoreUtils.printQuery(cqlQuery, showQuery);
-            if (log.isDebugEnabled())
-            {
+            if (log.isDebugEnabled()) {
                 log.debug("Executing cql query {}.", cqlQuery);
             }
             return conn.execute_cql_query(ByteBufferUtil.bytes(cqlQuery), org.apache.cassandra.thrift.Compression.NONE);
-        }
-        catch (Exception ex)
-        {
-            if (log.isErrorEnabled())
-            {
+        } catch (Exception ex) {
+            if (log.isErrorEnabled()) {
                 log.error("Error during executing query {}, Caused by: {} .", cqlQuery, ex);
             }
             throw new PersistenceException(ex);
-        }
-        finally
-        {
+        } finally {
             releaseConnection(pooledConnection);
         }
     }
 
     /**
-     * Find List of objects based on value {@columnValue} of column
-     * {@columnName}.
+     * Find List of objects based on value {@columnValue} of column {@columnName}.
      * 
      * @param m
      *            the m
@@ -2107,8 +1865,7 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      * @return the list
      */
     protected List<Object> findByRelationQuery(EntityMetadata m, String columnName, Object columnValue, Class clazz,
-            CassandraDataHandler dataHandler)
-    {
+        CassandraDataHandler dataHandler) {
         return cqlClient.findByRelationQuery(m, columnName, columnValue, clazz, dataHandler);
     }
 
@@ -2120,23 +1877,21 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      * @param puProperties
      *            the pu properties
      */
-    private void setBatchSize(String persistenceUnit, Map<String, Object> puProperties)
-    {
+    private void setBatchSize(String persistenceUnit, Map<String, Object> puProperties) {
         String batch_Size = null;
 
-        PersistenceUnitMetadata puMetadata = KunderaMetadataManager.getPersistenceUnitMetadata(kunderaMetadata,
-                persistenceUnit);
+        PersistenceUnitMetadata puMetadata =
+            KunderaMetadataManager.getPersistenceUnitMetadata(kunderaMetadata, persistenceUnit);
 
-        String externalBatchSize = puProperties != null ? (String) puProperties
-                .get(PersistenceProperties.KUNDERA_BATCH_SIZE) : null;
+        String externalBatchSize =
+            puProperties != null ? (String) puProperties.get(PersistenceProperties.KUNDERA_BATCH_SIZE) : null;
 
         Integer intbatch = null;
-        if (puMetadata.getBatchSize() > 0)
-        {
+        if (puMetadata.getBatchSize() > 0) {
             intbatch = new Integer(puMetadata.getBatchSize());
         }
-        batch_Size = (String) (externalBatchSize != null ? externalBatchSize : intbatch != null ? intbatch.toString()
-                : null);
+        batch_Size =
+            (String) (externalBatchSize != null ? externalBatchSize : intbatch != null ? intbatch.toString() : null);
 
         setBatchSize(batch_Size);
     }
@@ -2147,13 +1902,10 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      * @param batch_Size
      *            the new batch size
      */
-    void setBatchSize(String batch_Size)
-    {
-        if (!StringUtils.isBlank(batch_Size))
-        {
+    void setBatchSize(String batch_Size) {
+        if (!StringUtils.isBlank(batch_Size)) {
             batchSize = Integer.valueOf(batch_Size);
-            if (batchSize == 0)
-            {
+            if (batchSize == 0) {
                 throw new IllegalArgumentException("kundera.batch.size property must be numeric and > 0.");
             }
         }
@@ -2165,24 +1917,18 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      * @param externalProperties
      *            the external properties
      */
-    private void populateCqlVersion(Map<String, Object> externalProperties)
-    {
-        String cqlVersion = externalProperties != null ? (String) externalProperties
-                .get(CassandraConstants.CQL_VERSION) : null;
-        if (cqlVersion == null
-                || !(cqlVersion != null && (cqlVersion.equals(CassandraConstants.CQL_VERSION_2_0) || cqlVersion
-                        .equals(CassandraConstants.CQL_VERSION_3_0))))
-        {
+    private void populateCqlVersion(Map<String, Object> externalProperties) {
+        String cqlVersion =
+            externalProperties != null ? (String) externalProperties.get(CassandraConstants.CQL_VERSION) : null;
+        if (cqlVersion == null || !(cqlVersion != null && (cqlVersion.equals(CassandraConstants.CQL_VERSION_2_0)
+            || cqlVersion.equals(CassandraConstants.CQL_VERSION_3_0)))) {
             cqlVersion = (CassandraPropertyReader.csmd != null ? CassandraPropertyReader.csmd.getCqlVersion()
-                    : CassandraConstants.CQL_VERSION_2_0);
+                : CassandraConstants.CQL_VERSION_2_0);
         }
 
-        if (cqlVersion.equals(CassandraConstants.CQL_VERSION_3_0))
-        {
+        if (cqlVersion.equals(CassandraConstants.CQL_VERSION_3_0)) {
             setCqlVersion(CassandraConstants.CQL_VERSION_3_0);
-        }
-        else
-        {
+        } else {
             setCqlVersion(CassandraConstants.CQL_VERSION_2_0);
         }
     }
@@ -2218,8 +1964,7 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      * @author Kuldeep Mishra
      * 
      */
-    protected class CQLClient
-    {
+    protected class CQLClient {
 
         /**
          * Persist.
@@ -2248,14 +1993,12 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
          *             the schema disagreement exception
          */
         public void persist(EntityMetadata entityMetadata, Object entity,
-                org.apache.cassandra.thrift.Cassandra.Client conn, List<RelationHolder> rlHolders, Object ttlColumns)
-                throws UnsupportedEncodingException, InvalidRequestException, TException, UnavailableException,
-                TimedOutException, SchemaDisagreementException
-        {
+            org.apache.cassandra.thrift.Cassandra.Client conn, List<RelationHolder> rlHolders, Object ttlColumns)
+            throws UnsupportedEncodingException, InvalidRequestException, TException, UnavailableException,
+            TimedOutException, SchemaDisagreementException {
             List<String> queries = getPersistQueries(entityMetadata, entity, conn, rlHolders, ttlColumns);
 
-            for (String query : queries)
-            {
+            for (String query : queries) {
                 execute(query, conn);
 
             }
@@ -2279,28 +2022,23 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
          * @return the list
          */
         public List executeQuery(Class clazz, List<String> relationalField, CassandraDataHandler dataHandler,
-                boolean isCql3Enabled, boolean isNative, String cqlQuery)
-        {
+            boolean isCql3Enabled, boolean isNative, String cqlQuery) {
             EntityMetadata entityMetadata = KunderaMetadataManager.getEntityMetadata(kunderaMetadata, clazz);
 
             CqlResult result = null;
             List returnedEntities = new ArrayList();
-            try
-            {
-                if (log.isDebugEnabled())
-                {
+            try {
+                if (log.isDebugEnabled()) {
                     log.debug("Executing query {}.", cqlQuery);
                 }
                 result = (CqlResult) executeCQLQuery(cqlQuery, isCql3Enabled);
 
                 setCqlMetadata(result.getSchema());
 
-                if (result != null && (result.getRows() != null || result.getRowsSize() > 0))
-                {
+                if (result != null && (result.getRows() != null || result.getRowsSize() > 0)) {
                     returnedEntities = new ArrayList<Object>(result.getRowsSize());
                     Iterator<CqlRow> iter = result.getRowsIterator();
-                    while (iter.hasNext())
-                    {
+                    while (iter.hasNext()) {
                         Object e = null;
 
                         CqlRow row = iter.next();
@@ -2308,28 +2046,23 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
 
                         ThriftRow thriftRow = null;
                         thriftRow = new ThriftRow(rowKey, entityMetadata.getTableName(), row.getColumns(),
-                                new ArrayList<SuperColumn>(0), new ArrayList<CounterColumn>(0),
-                                new ArrayList<CounterSuperColumn>(0));
+                            new ArrayList<SuperColumn>(0), new ArrayList<CounterColumn>(0),
+                            new ArrayList<CounterSuperColumn>(0));
                         // send cqlmetadata
 
                         e = dataHandler.populateEntity(thriftRow, entityMetadata, KunderaCoreUtils.getEntity(e),
-                                relationalField, relationalField != null && !relationalField.isEmpty());
+                            relationalField, relationalField != null && !relationalField.isEmpty());
 
                         e = populateSecondaryTableData(relationalField, dataHandler, isCql3Enabled, entityMetadata, e);
 
-                        if (e != null)
-                        {
+                        if (e != null) {
                             returnedEntities.add(e);
-                        }
-                        else if (isNative)
-                        {
+                        } else if (isNative) {
                             returnedEntities.add(row.getColumns().get(0));
                         }
                     }
                 }
-            }
-            catch (Exception e)
-            {
+            } catch (Exception e) {
                 log.error("Error while executing native CQL query Caused by {}.", e);
                 throw new PersistenceException(e);
             }
@@ -2352,50 +2085,46 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
          * @return the object
          */
         private Object populateSecondaryTableData(List<String> relationalField, CassandraDataHandler dataHandler,
-                boolean isCql3Enabled, EntityMetadata entityMetadata, Object e)
-        {
+            boolean isCql3Enabled, EntityMetadata entityMetadata, Object e) {
             CqlResult result;
             // For secondary tables.
-            MetamodelImpl metaModel = (MetamodelImpl) kunderaMetadata.getApplicationMetadata().getMetamodel(
-                    entityMetadata.getPersistenceUnit());
-            if (!metaModel.isEmbeddable(entityMetadata.getIdAttribute().getBindableJavaType()))
-            {
-                AbstractManagedType managedType = (AbstractManagedType) metaModel.entity(entityMetadata
-                        .getEntityClazz());
-                List<String> secondaryTables = ((DefaultEntityAnnotationProcessor) managedType.getEntityAnnotation())
-                        .getSecondaryTablesName();
+            MetamodelImpl metaModel = (MetamodelImpl) kunderaMetadata.getApplicationMetadata()
+                .getMetamodel(entityMetadata.getPersistenceUnit());
+            if (!metaModel.isEmbeddable(entityMetadata.getIdAttribute().getBindableJavaType())) {
+                AbstractManagedType managedType =
+                    (AbstractManagedType) metaModel.entity(entityMetadata.getEntityClazz());
+                List<String> secondaryTables =
+                    ((DefaultEntityAnnotationProcessor) managedType.getEntityAnnotation()).getSecondaryTablesName();
 
                 CQLTranslator translator = new CQLTranslator();
 
-                for (String tableName : secondaryTables)
-                {
+                for (String tableName : secondaryTables) {
                     // Building query.
                     StringBuilder queryBuilder = new StringBuilder("select * from \"" + tableName + "\" where ");
                     Attribute attribute = entityMetadata.getIdAttribute();
-                    translator.buildWhereClause(queryBuilder, ((AbstractAttribute) entityMetadata.getIdAttribute())
-                            .getBindableJavaType(), CassandraUtilities.getIdColumnName(kunderaMetadata, entityMetadata,
-                            getExternalProperties(), isCql3Enabled(entityMetadata)), PropertyAccessorHelper.getId(e,
-                            entityMetadata), translator.EQ_CLAUSE, false);
+                    translator.buildWhereClause(queryBuilder,
+                        ((AbstractAttribute) entityMetadata.getIdAttribute()).getBindableJavaType(),
+                        CassandraUtilities.getIdColumnName(kunderaMetadata, entityMetadata, getExternalProperties(),
+                            isCql3Enabled(entityMetadata)),
+                        PropertyAccessorHelper.getId(e, entityMetadata), translator.EQ_CLAUSE, false);
                     // strip last "AND" clause.
                     queryBuilder.delete(queryBuilder.lastIndexOf(CQLTranslator.AND_CLAUSE), queryBuilder.length());
 
                     // Executing.
                     result = (CqlResult) executeCQLQuery(queryBuilder.toString(), isCql3Enabled);
 
-                    if (result != null && (result.getRows() != null || result.getRowsSize() > 0))
-                    {
+                    if (result != null && (result.getRows() != null || result.getRowsSize() > 0)) {
                         Iterator<CqlRow> iterator = result.getRowsIterator();
-                        while (iterator.hasNext())
-                        {
+                        while (iterator.hasNext()) {
                             CqlRow cqlRow = iterator.next();
 
                             ThriftRow tr = null;
                             tr = new ThriftRow(null, entityMetadata.getTableName(), cqlRow.getColumns(),
-                                    new ArrayList<SuperColumn>(0), new ArrayList<CounterColumn>(0),
-                                    new ArrayList<CounterSuperColumn>(0));
+                                new ArrayList<SuperColumn>(0), new ArrayList<CounterColumn>(0),
+                                new ArrayList<CounterSuperColumn>(0));
 
                             e = dataHandler.populateEntity(tr, entityMetadata, KunderaCoreUtils.getEntity(e),
-                                    relationalField, relationalField != null && !relationalField.isEmpty());
+                                relationalField, relationalField != null && !relationalField.isEmpty());
                             break;
                         }
                     }
@@ -2418,14 +2147,13 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
          * @return the list
          */
         public List<Object> find(MetamodelImpl metaModel, EntityMetadata metadata, Object rowId,
-                List<String> relationNames)
-        {
+            List<String> relationNames) {
             CQLTranslator translator = new CQLTranslator();
 
             String tableName = metadata.getTableName();
             String select_Query = translator.SELECTALL_QUERY;
             select_Query = StringUtils.replace(select_Query, CQLTranslator.COLUMN_FAMILY,
-                    translator.ensureCase(new StringBuilder(), tableName, false).toString());
+                translator.ensureCase(new StringBuilder(), tableName, false).toString());
             StringBuilder builder = new StringBuilder(select_Query);
             builder.append(CQLTranslator.ADD_WHERE_CLAUSE);
             onWhereClause(metadata, rowId, translator, builder, metaModel, metadata.getIdAttribute());
@@ -2433,12 +2161,11 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
             // strip last "AND" clause.
             builder.delete(builder.lastIndexOf(CQLTranslator.AND_CLAUSE), builder.length());
             return CassandraClientBase.this.executeQuery(metadata.getEntityClazz(), relationNames, false,
-                    builder.toString());
+                builder.toString());
         }
 
         /**
-         * Find List of objects based on value {@columnValue} of column
-         * {@columnName}.
+         * Find List of objects based on value {@columnValue} of column {@columnName}.
          * 
          * @param m
          *            the m
@@ -2452,23 +2179,22 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
          *            the data handler
          * @return the list
          */
-        protected List<Object> findByRelationQuery(EntityMetadata m, String columnName, Object columnValue,
-                Class clazz, CassandraDataHandler dataHandler)
-        {
+        protected List<Object> findByRelationQuery(EntityMetadata m, String columnName, Object columnValue, Class clazz,
+            CassandraDataHandler dataHandler) {
             CQLTranslator translator = new CQLTranslator();
             String selectQuery = translator.SELECTALL_QUERY;
             selectQuery = StringUtils.replace(selectQuery, CQLTranslator.COLUMN_FAMILY,
-                    translator.ensureCase(new StringBuilder(), m.getTableName(), false).toString());
+                translator.ensureCase(new StringBuilder(), m.getTableName(), false).toString());
 
             StringBuilder selectQueryBuilder = new StringBuilder(selectQuery);
             selectQueryBuilder.append(CQLTranslator.ADD_WHERE_CLAUSE);
 
             translator.buildWhereClause(selectQueryBuilder, columnValue.getClass(), columnName, columnValue,
-                    CQLTranslator.EQ_CLAUSE, false);
+                CQLTranslator.EQ_CLAUSE, false);
             selectQueryBuilder.delete(selectQueryBuilder.lastIndexOf(CQLTranslator.AND_CLAUSE),
-                    selectQueryBuilder.length());
+                selectQueryBuilder.length());
             return this.executeQuery(clazz, m.getRelationNames(), dataHandler, true, false,
-                    selectQueryBuilder.toString());
+                selectQueryBuilder.toString());
         }
     }
 
@@ -2477,8 +2203,7 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      * 
      * @return the ttlPerRequest
      */
-    public boolean isTtlPerRequest()
-    {
+    public boolean isTtlPerRequest() {
         return ttlPerRequest;
     }
 
@@ -2488,8 +2213,7 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      * @param ttlPerRequest
      *            the ttlPerRequest to set
      */
-    public void setTtlPerRequest(boolean ttlPerRequest)
-    {
+    public void setTtlPerRequest(boolean ttlPerRequest) {
         this.ttlPerRequest = ttlPerRequest;
     }
 
@@ -2498,8 +2222,7 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      * 
      * @return the ttlPerSession
      */
-    public boolean isTtlPerSession()
-    {
+    public boolean isTtlPerSession() {
         return ttlPerSession;
     }
 
@@ -2509,8 +2232,7 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      * @param ttlPerSession
      *            the ttlPerSession to set
      */
-    public void setTtlPerSession(boolean ttlPerSession)
-    {
+    public void setTtlPerSession(boolean ttlPerSession) {
         this.ttlPerSession = ttlPerSession;
     }
 
@@ -2519,8 +2241,7 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      * 
      * @return the ttlValues
      */
-    public Map<String, Object> getTtlValues()
-    {
+    public Map<String, Object> getTtlValues() {
         return ttlValues;
     }
 
@@ -2530,8 +2251,7 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      * @param ttlValues
      *            the ttlValues to set
      */
-    public void setTtlValues(Map<String, Object> ttlValues)
-    {
+    public void setTtlValues(Map<String, Object> ttlValues) {
         this.ttlValues = ttlValues;
     }
 
@@ -2551,48 +2271,38 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      * @return the list
      */
     public final List findByRowKeys(Class entityClass, List<String> relationNames, boolean isWrapReq,
-            EntityMetadata metadata, Object... rowIds)
-    {
+        EntityMetadata metadata, Object... rowIds) {
         List entities = null;
 
-        MetamodelImpl metaModel = (MetamodelImpl) kunderaMetadata.getApplicationMetadata().getMetamodel(
-                metadata.getPersistenceUnit());
+        MetamodelImpl metaModel =
+            (MetamodelImpl) kunderaMetadata.getApplicationMetadata().getMetamodel(metadata.getPersistenceUnit());
 
         EntityType entityType = metaModel.entity(metadata.getEntityClazz());
 
         List<AbstractManagedType> subManagedType = ((AbstractManagedType) entityType).getSubManagedType();
 
-        try
-        {
-            if (!subManagedType.isEmpty())
-            {
-                for (AbstractManagedType subEntity : subManagedType)
-                {
-                    EntityMetadata subEntityMetadata = KunderaMetadataManager.getEntityMetadata(kunderaMetadata,
-                            subEntity.getJavaType());
+        try {
+            if (!subManagedType.isEmpty()) {
+                for (AbstractManagedType subEntity : subManagedType) {
+                    EntityMetadata subEntityMetadata =
+                        KunderaMetadataManager.getEntityMetadata(kunderaMetadata, subEntity.getJavaType());
                     entities = getDataHandler().fromThriftRow(entityClass, subEntityMetadata,
-                            subEntityMetadata.getRelationNames(), isWrapReq, getConsistencyLevel(), rowIds);
+                        subEntityMetadata.getRelationNames(), isWrapReq, getConsistencyLevel(), rowIds);
 
-                    if (entities != null && !entities.isEmpty())
-                    {
+                    if (entities != null && !entities.isEmpty()) {
                         break;
                     }
                 }
-            }
-            else
-            {
+            } else {
                 entities = getDataHandler().fromThriftRow(entityClass, metadata, relationNames, isWrapReq,
-                        getConsistencyLevel(), rowIds);
+                    getConsistencyLevel(), rowIds);
             }
-        }
-        catch (Exception e)
-        {
+        } catch (Exception e) {
             log.error("Error while retrieving records for entity {}, row keys {}", entityClass, rowIds);
             throw new KunderaException(e);
         }
         return entities;
     }
-
 
     // XXX
     /**
@@ -2606,16 +2316,10 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      *            the connection
      * @return the t
      */
-    public <T> T execute(
-	final String query,
-	final Object connection,
-	final List<KunderaQuery.BindParameter> parameters
-    ) {
-	throw new KunderaException("not implemented");
+    public <T> T execute(final String query, final Object connection,
+        final List<KunderaQuery.BindParameter> parameters) {
+        throw new KunderaException("not implemented");
     }
-
- 
-
 
     /**
      * Execute.
@@ -2628,18 +2332,15 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      *            the connection
      * @return the t
      */
-    public <T> T execute(final String query, Object connection)
-    {
-        try
-        {
-            org.apache.cassandra.thrift.Cassandra.Client conn = (org.apache.cassandra.thrift.Cassandra.Client) connection;
+    public <T> T execute(final String query, Object connection) {
+        try {
+            org.apache.cassandra.thrift.Cassandra.Client conn =
+                (org.apache.cassandra.thrift.Cassandra.Client) connection;
             conn.set_cql_version(CassandraConstants.CQL_VERSION_3_0);
             KunderaCoreUtils.printQuery(query, showQuery);
             return (T) conn.execute_cql3_query(ByteBuffer.wrap(query.getBytes(Constants.CHARSET_UTF8)),
-                    Compression.NONE, getConsistencyLevel());
-        }
-        catch (Exception e)
-        {
+                Compression.NONE, getConsistencyLevel());
+        } catch (Exception e) {
             log.error("Error while executing query {}", query);
             throw new KunderaException(e);
         }
@@ -2653,14 +2354,13 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      * @param conn
      *            the conn
      */
-    protected void persistJoinTableByCql(JoinTableData joinTableData, Cassandra.Client conn)
-    {
+    protected void persistJoinTableByCql(JoinTableData joinTableData, Cassandra.Client conn) {
         String joinTableName = joinTableData.getJoinTableName();
         String invJoinColumnName = joinTableData.getInverseJoinColumnName();
         Map<Object, Set<Object>> joinTableRecords = joinTableData.getJoinTableRecords();
 
-        EntityMetadata entityMetadata = KunderaMetadataManager.getEntityMetadata(kunderaMetadata,
-                joinTableData.getEntityClass());
+        EntityMetadata entityMetadata =
+            KunderaMetadataManager.getEntityMetadata(kunderaMetadata, joinTableData.getEntityClass());
 
         // need to bring in an insert query for this
         // add columns & execute query
@@ -2678,7 +2378,7 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
         builder.append(translator.ensureCase(new StringBuilder(), joinTableData.getInverseJoinColumnName(), false));
 
         insert_Query = StringUtils.replace(insert_Query, CQLTranslator.COLUMN_FAMILY,
-                translator.ensureCase(new StringBuilder(), joinTableName, false).toString());
+            translator.ensureCase(new StringBuilder(), joinTableName, false).toString());
 
         insert_Query = StringUtils.replace(insert_Query, CQLTranslator.COLUMNS, builder.toString());
 
@@ -2688,37 +2388,33 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
 
         // insert query for each row key
 
-        for (Object key : joinTableRecords.keySet())
-        {
-            PropertyAccessor accessor = PropertyAccessorFactory.getPropertyAccessor((Field) entityMetadata
-                    .getIdAttribute().getJavaMember());
+        for (Object key : joinTableRecords.keySet()) {
+            PropertyAccessor accessor =
+                PropertyAccessorFactory.getPropertyAccessor((Field) entityMetadata.getIdAttribute().getJavaMember());
 
             Set<Object> values = joinTableRecords.get(key); // join column value
 
-            for (Object value : values)
-            {
-                if (value != null)
-                {
+            for (Object value : values) {
+                if (value != null) {
                     String insertQuery = insert_Query;
                     columnValueBuilder.append(CQLTranslator.QUOTE_STR);
-                    columnValueBuilder.append(PropertyAccessorHelper.getString(key) + "\001"
-                            + PropertyAccessorHelper.getString(value));
+                    columnValueBuilder.append(
+                        PropertyAccessorHelper.getString(key) + "\001" + PropertyAccessorHelper.getString(value));
                     columnValueBuilder.append(CQLTranslator.QUOTE_STR);
                     columnValueBuilder.append(CQLTranslator.COMMA_STR);
                     translator.appendValue(columnValueBuilder, key.getClass(), key, true, false);
                     columnValueBuilder.append(CQLTranslator.COMMA_STR);
                     translator.appendValue(columnValueBuilder, value.getClass(), value, true, false);
 
-                    insertQuery = StringUtils.replace(insertQuery, CQLTranslator.COLUMN_VALUES,
-                            columnValueBuilder.toString());
+                    insertQuery =
+                        StringUtils.replace(insertQuery, CQLTranslator.COLUMN_VALUES, columnValueBuilder.toString());
                     statements.append(insertQuery);
                     statements.append(" ");
                 }
             }
         }
 
-        if (!StringUtils.isBlank(statements.toString()))
-        {
+        if (!StringUtils.isBlank(statements.toString())) {
             batch_Query = StringUtils.replace(batch_Query, CQLTranslator.STATEMENT, statements.toString());
             StringBuilder batchBuilder = new StringBuilder();
             batchBuilder.append(batch_Query);
@@ -2748,36 +2444,33 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      * @return the columns by id using cql
      */
     protected <E> List<E> getColumnsByIdUsingCql(String schemaName, String tableName, String pKeyColumnName,
-            String columnName, Object pKeyColumnValue, Class columnJavaType)
-    {
+        String columnName, Object pKeyColumnValue, Class columnJavaType) {
         // select columnName from tableName where pKeyColumnName =
         // pKeyColumnValue
         List results = new ArrayList();
         CQLTranslator translator = new CQLTranslator();
         String selectQuery = translator.SELECT_QUERY;
         selectQuery = StringUtils.replace(selectQuery, CQLTranslator.COLUMN_FAMILY,
-                translator.ensureCase(new StringBuilder(), tableName, false).toString());
+            translator.ensureCase(new StringBuilder(), tableName, false).toString());
         selectQuery = StringUtils.replace(selectQuery, CQLTranslator.COLUMNS,
-                translator.ensureCase(new StringBuilder(), columnName, false).toString());
+            translator.ensureCase(new StringBuilder(), columnName, false).toString());
 
         StringBuilder selectQueryBuilder = new StringBuilder(selectQuery);
 
         selectQueryBuilder.append(CQLTranslator.ADD_WHERE_CLAUSE);
 
         translator.buildWhereClause(selectQueryBuilder, columnJavaType, pKeyColumnName, pKeyColumnValue,
-                CQLTranslator.EQ_CLAUSE, false);
-        selectQueryBuilder
-                .delete(selectQueryBuilder.lastIndexOf(CQLTranslator.AND_CLAUSE), selectQueryBuilder.length());
+            CQLTranslator.EQ_CLAUSE, false);
+        selectQueryBuilder.delete(selectQueryBuilder.lastIndexOf(CQLTranslator.AND_CLAUSE),
+            selectQueryBuilder.length());
 
         CqlResult cqlResult = execute(selectQueryBuilder.toString(), getRawClient(schemaName));
 
         Iterator<CqlRow> rowIter = cqlResult.getRows().iterator();
-        while (rowIter.hasNext())
-        {
+        while (rowIter.hasNext()) {
             CqlRow row = rowIter.next();
 
-            if (!row.getColumns().isEmpty())
-            {
+            if (!row.getColumns().isEmpty()) {
                 Column column = row.getColumns().get(0);
                 Object columnValue = CassandraDataTranslator.decompose(columnJavaType, column.getValue(), true);
                 results.add(columnValue);
@@ -2806,13 +2499,12 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      * @return the list
      */
     protected <E> List<E> findIdsByColumnUsingCql(String schemaName, String tableName, String pKeyName,
-            String columnName, Object columnValue, Class entityClazz)
-    {
+        String columnName, Object columnValue, Class entityClazz) {
         EntityMetadata metadata = KunderaMetadataManager.getEntityMetadata(kunderaMetadata, entityClazz);
 
         return getColumnsByIdUsingCql(schemaName, tableName, columnName,
-                ((AbstractAttribute) metadata.getIdAttribute()).getJPAColumnName(), columnValue, metadata
-                        .getIdAttribute().getBindableJavaType());
+            ((AbstractAttribute) metadata.getIdAttribute()).getJPAColumnName(), columnValue,
+            metadata.getIdAttribute().getBindableJavaType());
     }
 
     /**
@@ -2820,8 +2512,7 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      * 
      * @return the cql metadata
      */
-    public CqlMetadata getCqlMetadata()
-    {
+    public CqlMetadata getCqlMetadata() {
         return cqlMetadata;
     }
 
@@ -2831,8 +2522,7 @@ public abstract class CassandraClientBase extends ClientBase implements ClientPr
      * @param cqlMetadata
      *            the new cql metadata
      */
-    public void setCqlMetadata(CqlMetadata cqlMetadata)
-    {
+    public void setCqlMetadata(CqlMetadata cqlMetadata) {
         this.cqlMetadata = cqlMetadata;
     }
 }

--- a/src/kundera-cassandra/cassandra-core/src/main/java/com/impetus/client/cassandra/query/CassQuery.java
+++ b/src/kundera-cassandra/cassandra-core/src/main/java/com/impetus/client/cassandra/query/CassQuery.java
@@ -151,8 +151,24 @@ public class CassQuery extends QueryImpl
         {
             if (isNative)
             {
-                result = ((CassandraClientBase) client).executeQuery(m != null ? m.getEntityClazz() : null, null,
-                        isNative, query != null ? query : getJPAQuery());
+		    // XXX
+		if (
+		    !kunderaQuery.getBindParameters().isEmpty()
+		) {
+	                result = ((CassandraClientBase) client).executeQuery(
+				null,
+				null,
+				isNative, query != null ? query : getJPAQuery(),
+				kunderaQuery.getBindParameters()
+			);
+		} else {
+	                result = ((CassandraClientBase) client).executeQuery(
+				m != null ? m.getEntityClazz() : null,
+				null,
+				isNative,
+				query != null ? query : getJPAQuery()
+			);
+		}
             }
             else
             {

--- a/src/kundera-cassandra/cassandra-core/src/main/java/com/impetus/client/cassandra/query/CassQuery.java
+++ b/src/kundera-cassandra/cassandra-core/src/main/java/com/impetus/client/cassandra/query/CassQuery.java
@@ -81,8 +81,7 @@ import com.impetus.kundera.utils.ReflectUtils;
  *         Query implementation for Cassandra.
  */
 @SuppressWarnings("unchecked")
-public class CassQuery extends QueryImpl
-{
+public class CassQuery extends QueryImpl {
 
     /** the log used by this class. */
     private static Logger log = LoggerFactory.getLogger(CassQuery.class);
@@ -104,23 +103,19 @@ public class CassQuery extends QueryImpl
      *            the kundera metadata
      */
     public CassQuery(KunderaQuery kunderaQuery, PersistenceDelegator persistenceDelegator,
-            final KunderaMetadata kunderaMetadata)
-    {
+        final KunderaMetadata kunderaMetadata) {
         super(kunderaQuery, persistenceDelegator, kunderaMetadata);
     }
 
     /*
      * (non-Javadoc)
      * 
-     * @see
-     * com.impetus.kundera.query.QueryImpl#populateEntities(com.impetus.kundera
-     * .metadata.model.EntityMetadata, com.impetus.kundera.client.Client)
+     * @see com.impetus.kundera.query.QueryImpl#populateEntities(com.impetus.kundera .metadata.model.EntityMetadata,
+     * com.impetus.kundera.client.Client)
      */
     @Override
-    protected List<Object> populateEntities(EntityMetadata m, Client client)
-    {
-        if (log.isDebugEnabled())
-        {
+    protected List<Object> populateEntities(EntityMetadata m, Client client) {
+        if (log.isDebugEnabled()) {
             log.debug("Populating entities for Cassandra query {}.", getJPAQuery());
         }
         List<Object> result = new ArrayList<Object>();
@@ -131,71 +126,47 @@ public class CassQuery extends QueryImpl
         // make it independent of embedded stuff and allow even to add non
         // composite into where clause and let cassandra complain for it.
 
-        MetamodelImpl metaModel = (MetamodelImpl) kunderaMetadata.getApplicationMetadata().getMetamodel(
-                m != null ? m.getPersistenceUnit() : client.getPersistenceUnit());
+        MetamodelImpl metaModel = (MetamodelImpl) kunderaMetadata.getApplicationMetadata()
+            .getMetamodel(m != null ? m.getPersistenceUnit() : client.getPersistenceUnit());
 
         String query = appMetadata.getQuery(getJPAQuery());
         boolean isNative = kunderaQuery.isNative();
-        if (!isNative && !MetadataUtils.useSecondryIndex(((ClientBase) client).getClientMetadata()))
-        {
+        if (!isNative && !MetadataUtils.useSecondryIndex(((ClientBase) client).getClientMetadata())) {
             result = populateUsingLucene(m, client, result, getKunderaQuery().getResult());
         }
         // change for embeddable
         else if (!isNative && ((CassandraClientBase) client).isCql3Enabled(m)
-                && MetadataUtils.useSecondryIndex(((ClientBase) client).getClientMetadata()))
-        {
+            && MetadataUtils.useSecondryIndex(((ClientBase) client).getClientMetadata())) {
             result = ((CassandraClientBase) client).executeQuery(m.getEntityClazz(), null, isNative,
-                    onQueryOverCQL3(m, client, metaModel, null));
-        }
-        else
-        {
-            if (isNative)
-            {
-		    // XXX
-		if (
-		    !kunderaQuery.getBindParameters().isEmpty()
-		) {
-	                result = ((CassandraClientBase) client).executeQuery(
-				null,
-				null,
-				isNative, query != null ? query : getJPAQuery(),
-				kunderaQuery.getBindParameters()
-			);
-		} else {
-	                result = ((CassandraClientBase) client).executeQuery(
-				m != null ? m.getEntityClazz() : null,
-				null,
-				isNative,
-				query != null ? query : getJPAQuery()
-			);
-		}
-            }
-            else
-            {
-                if (MetadataUtils.useSecondryIndex(((ClientBase) client).getClientMetadata()))
-                {
+                onQueryOverCQL3(m, client, metaModel, null));
+        } else {
+            if (isNative) {
+                // XXX
+                if (!kunderaQuery.getBindParameters().isEmpty()) {
+                    result = ((CassandraClientBase) client).executeQuery(null, null, isNative,
+                        query != null ? query : getJPAQuery(), kunderaQuery.getBindParameters());
+                } else {
+                    result = ((CassandraClientBase) client).executeQuery(m != null ? m.getEntityClazz() : null, null,
+                        isNative, query != null ? query : getJPAQuery());
+                }
+            } else {
+                if (MetadataUtils.useSecondryIndex(((ClientBase) client).getClientMetadata())) {
                     // Index in Inverted Index table if applicable
                     boolean useInvertedIndex = CassandraIndexHelper.isInvertedIndexingApplicable(m,
-                            MetadataUtils.useSecondryIndex(((ClientBase) client).getClientMetadata()));
+                        MetadataUtils.useSecondryIndex(((ClientBase) client).getClientMetadata()));
                     Map<Boolean, List<IndexClause>> ixClause = prepareIndexClause(m, useInvertedIndex);
-                    if (useInvertedIndex && !getKunderaQuery().getFilterClauseQueue().isEmpty())
-                    {
+                    if (useInvertedIndex && !getKunderaQuery().getFilterClauseQueue().isEmpty()) {
                         result = (List) ((CassandraEntityReader) getReader()).readFromIndexTable(m, client, ixClause);
-                    }
-                    else
-                    {
+                    } else {
                         boolean isRowKeyQuery = ixClause.keySet().iterator().next();
-                        if (!isRowKeyQuery)
-                        {
+                        if (!isRowKeyQuery) {
                             result = ((CassandraClientBase) client).find(ixClause.get(isRowKeyQuery), m, false, null,
-                                    isSingleResult ? 1 : this.maxResult,
-                                    getColumnList(m, metaModel, getKunderaQuery().getResult(), null));
-                        }
-                        else
-                        {
-                            result = ((CassandraEntityReader) getReader()).handleFindByRange(m, client, result,
-                                    ixClause, isRowKeyQuery,
-                                    getColumnList(m, metaModel, getKunderaQuery().getResult(), null),
+                                isSingleResult ? 1 : this.maxResult,
+                                getColumnList(m, metaModel, getKunderaQuery().getResult(), null));
+                        } else {
+                            result =
+                                ((CassandraEntityReader) getReader()).handleFindByRange(m, client, result, ixClause,
+                                    isRowKeyQuery, getColumnList(m, metaModel, getKunderaQuery().getResult(), null),
                                     isSingleResult ? 1 : this.maxResult);
                         }
                     }
@@ -209,28 +180,22 @@ public class CassQuery extends QueryImpl
     /*
      * (non-Javadoc)
      * 
-     * @see
-     * com.impetus.kundera.query.QueryImpl#findUsingLucene(com.impetus.kundera
-     * .metadata.model.EntityMetadata, com.impetus.kundera.client.Client)
+     * @see com.impetus.kundera.query.QueryImpl#findUsingLucene(com.impetus.kundera .metadata.model.EntityMetadata,
+     * com.impetus.kundera.client.Client)
      */
-    protected List findUsingLucene(EntityMetadata m, Client client)
-    {
-        MetamodelImpl metaModel = (MetamodelImpl) kunderaMetadata.getApplicationMetadata().getMetamodel(
-                m.getPersistenceUnit());
+    protected List findUsingLucene(EntityMetadata m, Client client) {
+        MetamodelImpl metaModel =
+            (MetamodelImpl) kunderaMetadata.getApplicationMetadata().getMetamodel(m.getPersistenceUnit());
         boolean useInvertedIndex = CassandraIndexHelper.isInvertedIndexingApplicable(m,
-                MetadataUtils.useSecondryIndex(((ClientBase) client).getClientMetadata()));
+            MetadataUtils.useSecondryIndex(((ClientBase) client).getClientMetadata()));
         Map<Boolean, List<IndexClause>> ixClause = prepareIndexClause(m, useInvertedIndex);
         List<Object> result = new ArrayList<Object>();
-        if (((CassandraClientBase) client).isCql3Enabled(m))
-        {
+        if (((CassandraClientBase) client).isCql3Enabled(m)) {
             result = ((CassandraClientBase) client).executeQuery(m.getEntityClazz(), m.getRelationNames(), false,
-                    onQueryOverCQL3(m, client, metaModel, m.getRelationNames()));
-        }
-        else
-        {
+                onQueryOverCQL3(m, client, metaModel, m.getRelationNames()));
+        } else {
             result = ((CassandraEntityReader) getReader()).handleFindByRange(m, client, result, ixClause, true,
-                    getColumnList(m, metaModel, getKunderaQuery().getResult(), null), isSingleResult ? 1
-                            : this.maxResult);
+                getColumnList(m, metaModel, getKunderaQuery().getResult(), null), isSingleResult ? 1 : this.maxResult);
         }
         return result;
     }
@@ -244,56 +209,44 @@ public class CassQuery extends QueryImpl
      *            the client
      * @return the list
      * @see com.impetus.kundera.query.QueryImpl#recursivelyPopulateEntities(com.impetus
-     *      .kundera.metadata.model.EntityMetadata,
-     *      com.impetus.kundera.client.Client)
+     *      .kundera.metadata.model.EntityMetadata, com.impetus.kundera.client.Client)
      */
     @SuppressWarnings("unchecked")
     @Override
-    protected List<Object> recursivelyPopulateEntities(EntityMetadata m, Client client)
-    {
+    protected List<Object> recursivelyPopulateEntities(EntityMetadata m, Client client) {
         List<EnhanceEntity> ls = null;
         ApplicationMetadata appMetadata = kunderaMetadata.getApplicationMetadata();
         externalProperties = ((CassandraClientBase) client).getExternalProperties();
-        MetamodelImpl metaModel = (MetamodelImpl) kunderaMetadata.getApplicationMetadata().getMetamodel(
-                m.getPersistenceUnit());
+        MetamodelImpl metaModel =
+            (MetamodelImpl) kunderaMetadata.getApplicationMetadata().getMetamodel(m.getPersistenceUnit());
 
         String query = appMetadata.getQuery(getJPAQuery());
         boolean isNative = kunderaQuery.isNative();
 
-        if (isNative)
-        {
+        if (isNative) {
             ls = (List<EnhanceEntity>) ((CassandraClientBase) client).executeQuery(m.getEntityClazz(),
-                    m.getRelationNames(), isNative, query != null ? query : getJPAQuery());
-        }
-        else if (!isNative && ((CassandraClientBase) client).isCql3Enabled(m))
-        {
+                m.getRelationNames(), isNative, query != null ? query : getJPAQuery());
+        } else if (!isNative && ((CassandraClientBase) client).isCql3Enabled(m)) {
             // edited
             // check if lucene or indexer are enabled then populate
-            if (MetadataUtils.useSecondryIndex(((ClientBase) client).getClientMetadata()))
-            {
+            if (MetadataUtils.useSecondryIndex(((ClientBase) client).getClientMetadata())) {
                 ls = ((CassandraClientBase) client).executeQuery(m.getEntityClazz(), m.getRelationNames(), isNative,
 
-                onQueryOverCQL3(m, client, metaModel, m.getRelationNames()));
-            }
-            else
-            {
+                    onQueryOverCQL3(m, client, metaModel, m.getRelationNames()));
+            } else {
                 ls = populateUsingLucene(m, client, null, getKunderaQuery().getResult());
             }
-        }
-        else
-        {
+        } else {
             // Index in Inverted Index table if applicable
             boolean useInvertedIndex = CassandraIndexHelper.isInvertedIndexingApplicable(m,
-                    MetadataUtils.useSecondryIndex(((ClientBase) client).getClientMetadata()));
-            Map<Boolean, List<IndexClause>> ixClause = MetadataUtils.useSecondryIndex(((ClientBase) client)
-                    .getClientMetadata()) ? prepareIndexClause(m, useInvertedIndex) : null;
+                MetadataUtils.useSecondryIndex(((ClientBase) client).getClientMetadata()));
+            Map<Boolean, List<IndexClause>> ixClause =
+                MetadataUtils.useSecondryIndex(((ClientBase) client).getClientMetadata())
+                    ? prepareIndexClause(m, useInvertedIndex) : null;
 
-            if (useInvertedIndex && !getKunderaQuery().getFilterClauseQueue().isEmpty())
-            {
+            if (useInvertedIndex && !getKunderaQuery().getFilterClauseQueue().isEmpty()) {
                 ls = ((CassandraEntityReader) getReader()).readFromIndexTable(m, client, ixClause);
-            }
-            else
-            {
+            } else {
                 ((CassandraEntityReader) getReader()).setConditions(ixClause);
                 ls = reader.populateRelation(m, client, isSingleResult ? 1 : this.maxResult);
             }
@@ -307,11 +260,10 @@ public class CassQuery extends QueryImpl
      * @return zero
      */
     @Override
-    protected int onExecuteUpdate()
-    {
+    protected int onExecuteUpdate() {
         EntityMetadata m = getEntityMetadata();
-        Client client = m != null ? persistenceDelegeator.getClient(m) : persistenceDelegeator.getClient(kunderaQuery
-                .getPersistenceUnit());
+        Client client = m != null ? persistenceDelegeator.getClient(m)
+            : persistenceDelegeator.getClient(kunderaQuery.getPersistenceUnit());
         externalProperties = ((CassandraClientBase) client).getExternalProperties();
         ApplicationMetadata appMetadata = kunderaMetadata.getApplicationMetadata();
 
@@ -319,29 +271,20 @@ public class CassQuery extends QueryImpl
 
         boolean isNative = kunderaQuery.isNative();
 
-        if (isNative)
-        {
+        if (isNative) {
             ((CassandraClientBase) client).executeQuery(m == null ? null : m.getEntityClazz(), null, isNative,
-                    query != null ? query : getJPAQuery());
-        }
-        else if (kunderaQuery.isDeleteUpdate())
-        {
+                query != null ? query : getJPAQuery());
+        } else if (kunderaQuery.isDeleteUpdate()) {
             // If query is not convertible to CQL, fetch and merge records usual
             // way, otherwise
             // convert to CQL and execute
-            if (!isQueryConvertibleToCQL(kunderaQuery))
-            {
+            if (!isQueryConvertibleToCQL(kunderaQuery)) {
                 return onUpdateDeleteEvent();
-            }
-            else
-            {
+            } else {
                 query = null;
-                if (kunderaQuery.isUpdateClause())
-                {
+                if (kunderaQuery.isUpdateClause()) {
                     query = createUpdateQuery(kunderaQuery);
-                }
-                else
-                {
+                } else {
                     query = createDeleteQuery(kunderaQuery);
                 }
                 return ((CassandraClientBase) client).executeUpdateDeleteQuery(query);
@@ -357,25 +300,20 @@ public class CassQuery extends QueryImpl
      *            the kundera query
      * @return true, if is query convertible to cql
      */
-    private boolean isQueryConvertibleToCQL(KunderaQuery kunderaQuery)
-    {
+    private boolean isQueryConvertibleToCQL(KunderaQuery kunderaQuery) {
         EntityMetadata m = kunderaQuery.getEntityMetadata();
         if (kunderaQuery.isUpdateClause() && m.isCounterColumnType())
             return false;
 
         List<String> opsNotAllowed = Arrays.asList(new String[] { ">", "<", ">=", "<=" });
         boolean result = false;
-        if (!kunderaQuery.getFilterClauseQueue().isEmpty())
-        {
+        if (!kunderaQuery.getFilterClauseQueue().isEmpty()) {
             String idColumn = ((AbstractAttribute) m.getIdAttribute()).getJPAColumnName();
-            for (Object o : kunderaQuery.getFilterClauseQueue())
-            {
-                if (o instanceof FilterClause)
-                {
+            for (Object o : kunderaQuery.getFilterClauseQueue()) {
+                if (o instanceof FilterClause) {
                     FilterClause filterClause = (FilterClause) o;
                     if (!idColumn.equals(filterClause.getProperty())
-                            || opsNotAllowed.contains(filterClause.getCondition()))
-                    {
+                        || opsNotAllowed.contains(filterClause.getCondition())) {
                         result = false;
                         break;
                     }
@@ -399,52 +337,38 @@ public class CassQuery extends QueryImpl
      *            the compound key
      * @return the column list
      */
-    List<String> getColumnList(EntityMetadata m, MetamodelImpl metamodel, String[] results, EmbeddableType compoundKey)
-    {
+    List<String> getColumnList(EntityMetadata m, MetamodelImpl metamodel, String[] results,
+        EmbeddableType compoundKey) {
         List<String> columns = new ArrayList<String>();
-        if (results != null && results.length > 0)
-        {
-            MetamodelImpl metaModel = (MetamodelImpl) kunderaMetadata.getApplicationMetadata().getMetamodel(
-                    m.getPersistenceUnit());
+        if (results != null && results.length > 0) {
+            MetamodelImpl metaModel =
+                (MetamodelImpl) kunderaMetadata.getApplicationMetadata().getMetamodel(m.getPersistenceUnit());
             EntityType entity = metaModel.entity(m.getEntityClazz());
 
             String keyFieldName = CassandraUtilities.getIdColumnName(kunderaMetadata, m, externalProperties,
-                    ((CassandraClientBase) persistenceDelegeator.getClient(m)).isCql3Enabled(m));
-            for (int i = 1; i < results.length; i++)
-            {
-                if (results[i] != null)
-                {
-                    if (results[i].indexOf(".") > 0)
-                    {
+                ((CassandraClientBase) persistenceDelegeator.getClient(m)).isCql3Enabled(m));
+            for (int i = 1; i < results.length; i++) {
+                if (results[i] != null) {
+                    if (results[i].indexOf(".") > 0) {
                         String fieldName = results[i].substring(0, results[i].indexOf("."));
-                        String embeddedFieldName = results[i].substring(results[i].indexOf(".") + 1,
-                                results[i].length());
+                        String embeddedFieldName =
+                            results[i].substring(results[i].indexOf(".") + 1, results[i].length());
                         AbstractAttribute attribute = (AbstractAttribute) entity.getAttribute(fieldName);
                         EmbeddableType embeddable = metamodel.embeddable(attribute.getBindableJavaType());
                         Attribute embeddableAttribute = embeddable.getAttribute(embeddedFieldName);
                         columns.add(((AbstractAttribute) embeddableAttribute).getJPAColumnName());
-                    }
-                    else
-                    {
+                    } else {
                         Attribute attribute = entity.getAttribute(results[i]);
-                        if (attribute == null)
-                        {
+                        if (attribute == null) {
                             throw new QueryHandlerException("Column type is null for : " + results);
-                        }
-                        else if (m.getIdAttribute().equals(attribute) && compoundKey != null)
-                        {
+                        } else if (m.getIdAttribute().equals(attribute) && compoundKey != null) {
                             Field[] fields = m.getIdAttribute().getBindableJavaType().getDeclaredFields();
-                            for (Field field : fields)
-                            {
+                            for (Field field : fields) {
                                 addCompositeIdToColumns(metamodel, compoundKey, columns, field);
                             }
-                        }
-                        else if (m.getIdAttribute().equals(attribute) && compoundKey == null)
-                        {
+                        } else if (m.getIdAttribute().equals(attribute) && compoundKey == null) {
                             columns.add(keyFieldName);
-                        }
-                        else
-                        {
+                        } else {
                             columns.add(((AbstractAttribute) attribute).getJPAColumnName());
                         }
                     }
@@ -453,8 +377,7 @@ public class CassQuery extends QueryImpl
             return columns;
         }
 
-        if (log.isInfoEnabled())
-        {
+        if (log.isInfoEnabled()) {
             log.info("No record found, returning null.");
         }
         return null;
@@ -473,27 +396,20 @@ public class CassQuery extends QueryImpl
      *            the field
      */
     private void addCompositeIdToColumns(MetamodelImpl metamodel, EmbeddableType compoundKey, List<String> columns,
-            Field field)
-    {
-        if (!ReflectUtils.isTransientOrStatic(field))
-        {
+        Field field) {
+        if (!ReflectUtils.isTransientOrStatic(field)) {
             Attribute compositeColumn = compoundKey.getAttribute(field.getName());
-            if (compositeColumn.getJavaType().isAnnotationPresent(Embeddable.class))
-            {
+            if (compositeColumn.getJavaType().isAnnotationPresent(Embeddable.class)) {
                 // partition key
                 EmbeddableType partitionCol = metamodel.embeddable(compositeColumn.getJavaType());
                 Set<Attribute> cols = partitionCol.getAttributes();
-                for (Attribute col : cols)
-                {
+                for (Attribute col : cols) {
                     Field f = (Field) col.getJavaMember();
-                    if (!ReflectUtils.isTransientOrStatic(f))
-                    {
+                    if (!ReflectUtils.isTransientOrStatic(f)) {
                         columns.add(((AbstractAttribute) col).getJPAColumnName());
                     }
                 }
-            }
-            else
-            {
+            } else {
                 columns.add(((AbstractAttribute) compositeColumn).getJPAColumnName());
             }
         }
@@ -508,10 +424,9 @@ public class CassQuery extends QueryImpl
      *            the is query for inverted index
      * @return the map
      */
-    Map<Boolean, List<IndexClause>> prepareIndexClause(EntityMetadata m, boolean isQueryForInvertedIndex)
-    {
-        IndexClause indexClause = new IndexClause(new ArrayList<IndexExpression>(), ByteBufferUtil.EMPTY_BYTE_BUFFER,
-                maxResult);
+    Map<Boolean, List<IndexClause>> prepareIndexClause(EntityMetadata m, boolean isQueryForInvertedIndex) {
+        IndexClause indexClause =
+            new IndexClause(new ArrayList<IndexExpression>(), ByteBufferUtil.EMPTY_BYTE_BUFFER, maxResult);
 
         List<IndexClause> clauses = new ArrayList<IndexClause>();
         List<IndexExpression> expr = new ArrayList<IndexExpression>();
@@ -521,52 +436,43 @@ public class CassQuery extends QueryImpl
         String idColumn = ((AbstractAttribute) m.getIdAttribute()).getJPAColumnName();
         boolean idPresent = false;
 
-        if (log.isInfoEnabled())
-        {
+        if (log.isInfoEnabled()) {
             log.info("Preparing index clause for query {}", getJPAQuery());
         }
 
-        for (Object o : getKunderaQuery().getFilterClauseQueue())
-        {
-            if (o instanceof FilterClause)
-            {
+        for (Object o : getKunderaQuery().getFilterClauseQueue()) {
+            if (o instanceof FilterClause) {
                 FilterClause clause = ((FilterClause) o);
                 String fieldName = clause.getProperty();
                 // in case id column matches with field name, set it for first
                 // time.
-                if (!idPresent && idColumn.equalsIgnoreCase(fieldName))
-                {
+                if (!idPresent && idColumn.equalsIgnoreCase(fieldName)) {
                     idPresent = true;
                 }
 
                 String condition = clause.getCondition();
                 List<Object> value = clause.getValue();
-                if (value != null && value.size() > 1)
-                {
+                if (value != null && value.size() > 1) {
                     log.error("IN clause is not enabled for thrift, use cql3.");
                     throw new QueryHandlerException("IN clause is not enabled for thrift, use cql3.");
                 }
                 IndexOperator operator = getOperator(condition, idPresent);
 
                 IndexExpression expression = new IndexExpression(ByteBufferUtil.bytes(fieldName), operator,
-                        getBytesValue(fieldName, m, value.get(0)));
+                    getBytesValue(fieldName, m, value.get(0)));
 
                 expr.add(expression);
-            }
-            else
-            {
+            } else {
                 // Case of AND and OR clause.
                 String opr = o.toString();
-                if (opr.equalsIgnoreCase("or"))
-                {
+                if (opr.equalsIgnoreCase("or")) {
                     log.error("Support for OR clause is not enabled within cassandra.");
                     throw new QueryHandlerException("Unsupported clause " + opr + " for cassandra.");
                 }
             }
         }
 
-        if (!StringUtils.isBlank(getKunderaQuery().getFilter()))
-        {
+        if (!StringUtils.isBlank(getKunderaQuery().getFilter())) {
             indexClause.setExpressions(expr);
             clauses.add(indexClause);
         }
@@ -584,38 +490,23 @@ public class CassQuery extends QueryImpl
      *            the id present
      * @return the operator
      */
-    private IndexOperator getOperator(String condition, boolean idPresent)
-    {
-        if (/* !idPresent && */condition.equals("="))
-        {
+    private IndexOperator getOperator(String condition, boolean idPresent) {
+        if (/* !idPresent && */condition.equals("=")) {
             return IndexOperator.EQ;
-        }
-        else if (/* !idPresent && */condition.equals(">"))
-        {
+        } else if (/* !idPresent && */condition.equals(">")) {
             return IndexOperator.GT;
-        }
-        else if (/* !idPresent && */condition.equals("<"))
-        {
+        } else if (/* !idPresent && */condition.equals("<")) {
             return IndexOperator.LT;
-        }
-        else if (condition.equals(">="))
-        {
+        } else if (condition.equals(">=")) {
             return IndexOperator.GTE;
-        }
-        else if (condition.equals("<="))
-        {
+        } else if (condition.equals("<=")) {
             return IndexOperator.LTE;
-        }
-        else
-        {
-            if (!idPresent)
-            {
+        } else {
+            if (!idPresent) {
                 throw new UnsupportedOperationException("Condition " + condition + " is not suported in  cassandra.");
-            }
-            else
-            {
-                throw new UnsupportedOperationException("Condition " + condition
-                        + " is not suported for query on row key.");
+            } else {
+                throw new UnsupportedOperationException(
+                    "Condition " + condition + " is not suported for query on row key.");
             }
         }
 
@@ -627,10 +518,8 @@ public class CassQuery extends QueryImpl
      * @see com.impetus.kundera.query.QueryImpl#getReader()
      */
     @Override
-    protected EntityReader getReader()
-    {
-        if (reader == null)
-        {
+    protected EntityReader getReader() {
+        if (reader == null) {
             reader = new CassandraEntityReader(kunderaQuery, kunderaMetadata);
         }
         return reader;
@@ -647,67 +536,50 @@ public class CassQuery extends QueryImpl
      *            value.
      * @return bytes value.
      */
-    ByteBuffer getBytesValue(String jpaFieldName, EntityMetadata m, Object value)
-    {
+    ByteBuffer getBytesValue(String jpaFieldName, EntityMetadata m, Object value) {
         Attribute idCol = m.getIdAttribute();
-        MetamodelImpl metaModel = (MetamodelImpl) kunderaMetadata.getApplicationMetadata().getMetamodel(
-                m.getPersistenceUnit());
+        MetamodelImpl metaModel =
+            (MetamodelImpl) kunderaMetadata.getApplicationMetadata().getMetamodel(m.getPersistenceUnit());
 
         EntityType entity = metaModel.entity(m.getEntityClazz());
         Field f = null;
         boolean isId = false;
-        if (((AbstractAttribute) idCol).getJPAColumnName().equals(jpaFieldName))
-        {
+        if (((AbstractAttribute) idCol).getJPAColumnName().equals(jpaFieldName)) {
             f = (Field) idCol.getJavaMember();
             isId = true;
-        }
-        else
-        {
-            if (jpaFieldName != null && jpaFieldName.indexOf(Constants.INDEX_TABLE_ROW_KEY_DELIMITER) > 0)
-            {
-                String embeddedFieldName = jpaFieldName.substring(0,
-                        jpaFieldName.indexOf(Constants.INDEX_TABLE_ROW_KEY_DELIMITER));
+        } else {
+            if (jpaFieldName != null && jpaFieldName.indexOf(Constants.INDEX_TABLE_ROW_KEY_DELIMITER) > 0) {
+                String embeddedFieldName =
+                    jpaFieldName.substring(0, jpaFieldName.indexOf(Constants.INDEX_TABLE_ROW_KEY_DELIMITER));
                 String columnFieldName = jpaFieldName.substring(
-                        jpaFieldName.indexOf(Constants.INDEX_TABLE_ROW_KEY_DELIMITER) + 1, jpaFieldName.length());
+                    jpaFieldName.indexOf(Constants.INDEX_TABLE_ROW_KEY_DELIMITER) + 1, jpaFieldName.length());
 
                 Attribute embeddedAttr = entity.getAttribute(embeddedFieldName);
-                try
-                {
+                try {
                     Class<?> embeddedClass = embeddedAttr.getJavaType();
-                    if (Collection.class.isAssignableFrom(embeddedClass))
-                    {
-                        Class<?> genericClass = PropertyAccessorHelper.getGenericClass((Field) embeddedAttr
-                                .getJavaMember());
+                    if (Collection.class.isAssignableFrom(embeddedClass)) {
+                        Class<?> genericClass =
+                            PropertyAccessorHelper.getGenericClass((Field) embeddedAttr.getJavaMember());
                         f = genericClass.getDeclaredField(columnFieldName);
-                    }
-                    else
-                    {
+                    } else {
                         f = embeddedClass.getDeclaredField(columnFieldName);
                     }
 
-                }
-                catch (SecurityException e)
-                {
+                } catch (SecurityException e) {
+                    log.error("Error while extrating " + jpaFieldName + ", Caused by: ", e);
+                    throw new QueryHandlerException("Error while extrating " + jpaFieldName + ".");
+                } catch (NoSuchFieldException e) {
                     log.error("Error while extrating " + jpaFieldName + ", Caused by: ", e);
                     throw new QueryHandlerException("Error while extrating " + jpaFieldName + ".");
                 }
-                catch (NoSuchFieldException e)
-                {
-                    log.error("Error while extrating " + jpaFieldName + ", Caused by: ", e);
-                    throw new QueryHandlerException("Error while extrating " + jpaFieldName + ".");
-                }
-            }
-            else
-            {
+            } else {
                 String discriminatorColumn = ((AbstractManagedType) entity).getDiscriminatorColumn();
 
-                if (!jpaFieldName.equals(discriminatorColumn))
-                {
+                if (!jpaFieldName.equals(discriminatorColumn)) {
                     String fieldName = m.getFieldName(jpaFieldName);
 
                     Attribute col = entity.getAttribute(fieldName);
-                    if (col == null)
-                    {
+                    if (col == null) {
                         throw new QueryHandlerException("column type is null for: " + jpaFieldName);
                     }
                     f = (Field) col.getJavaMember();
@@ -717,12 +589,9 @@ public class CassQuery extends QueryImpl
 
         // need to do integer.parseInt..as value will be string in case of
         // create query.
-        if (f != null && f.getType() != null)
-        {
+        if (f != null && f.getType() != null) {
             return CassandraUtilities.toBytes(value, f);
-        }
-        else
-        {
+        } else {
             // default is String type
             return CassandraUtilities.toBytes(value, String.class);
         }
@@ -741,21 +610,17 @@ public class CassQuery extends QueryImpl
      *            the relations
      * @return the list
      */
-    public String onQueryOverCQL3(EntityMetadata m, Client client, MetamodelImpl metaModel, List<String> relations)
-    {
+    public String onQueryOverCQL3(EntityMetadata m, Client client, MetamodelImpl metaModel, List<String> relations) {
         // select column will always be of entity field only!
         // where clause ordering
 
         Class compoundKeyClass = m.getIdAttribute().getBindableJavaType();
         EmbeddableType compoundKey = null;
         String idColumn;
-        if (metaModel.isEmbeddable(compoundKeyClass))
-        {
+        if (metaModel.isEmbeddable(compoundKeyClass)) {
             compoundKey = metaModel.embeddable(compoundKeyClass);
             idColumn = ((AbstractAttribute) m.getIdAttribute()).getJPAColumnName();
-        }
-        else
-        {
+        } else {
             idColumn = ((AbstractAttribute) m.getIdAttribute()).getJPAColumnName();
         }
         StringBuilder builder = new StringBuilder();
@@ -767,7 +632,7 @@ public class CassQuery extends QueryImpl
         CQLTranslator translator = new CQLTranslator();
 
         selectQuery = StringUtils.replace(selectQuery, CQLTranslator.COLUMN_FAMILY,
-                translator.ensureCase(new StringBuilder(), m.getTableName(), false).toString());
+            translator.ensureCase(new StringBuilder(), m.getTableName(), false).toString());
 
         builder = CassandraUtilities.appendColumns(builder, columns, selectQuery, translator);
 
@@ -785,19 +650,15 @@ public class CassQuery extends QueryImpl
      *            the columns
      * @return the string
      */
-    private String setSelectQuery(List<String> columns)
-    {
-        if (columns != null && !columns.isEmpty())
-        {
+    private String setSelectQuery(List<String> columns) {
+        if (columns != null && !columns.isEmpty()) {
             return CQLTranslator.SELECT_QUERY;
         }
-        if (kunderaQuery.isAggregated())
-        {
-            Expression selectExpression = ((SelectClause) kunderaQuery.getSelectStatement().getSelectClause())
-                    .getSelectExpression();
+        if (kunderaQuery.isAggregated()) {
+            Expression selectExpression =
+                ((SelectClause) kunderaQuery.getSelectStatement().getSelectClause()).getSelectExpression();
             // create query depending on function
-            if (selectExpression instanceof CountFunction)
-            {
+            if (selectExpression instanceof CountFunction) {
                 return CQLTranslator.SELECT_COUNT_QUERY;
             }
         }
@@ -810,10 +671,8 @@ public class CassQuery extends QueryImpl
      * @param builder
      *            string builder.
      */
-    private void onLimit(StringBuilder builder)
-    {
-        if (Integer.MAX_VALUE != maxResult)
-        {
+    private void onLimit(StringBuilder builder) {
+        if (Integer.MAX_VALUE != maxResult) {
             builder.append(CQLTranslator.LIMIT);
             builder.append(isSingleResult ? 1 : this.maxResult);
         }
@@ -841,14 +700,11 @@ public class CassQuery extends QueryImpl
      * @return true, if successful
      */
     private boolean onCondition(EntityMetadata m, MetamodelImpl metaModel, EmbeddableType keyObj, String idColumn,
-            StringBuilder builder, boolean isPresent, CQLTranslator translator, boolean use)
-    {
+        StringBuilder builder, boolean isPresent, CQLTranslator translator, boolean use) {
         String partitionKey = null;
         boolean allowFiltering = false;
-        for (Object o : getKunderaQuery().getFilterClauseQueue())
-        {
-            if (o instanceof FilterClause)
-            {
+        for (Object o : getKunderaQuery().getFilterClauseQueue()) {
+            if (o instanceof FilterClause) {
                 FilterClause clause = ((FilterClause) o);
                 String fieldName = clause.getProperty();
                 String condition = clause.getCondition();
@@ -858,79 +714,64 @@ public class CassQuery extends QueryImpl
                 // if compound key field is given in where clause.
                 isPresent = true;
 
-                if (keyObj != null && idColumn.equals(fieldName))
-                {
+                if (keyObj != null && idColumn.equals(fieldName)) {
                     Field[] fields = m.getIdAttribute().getBindableJavaType().getDeclaredFields();
 
                     Map<Attribute, List<Object>> columnValues = new HashMap<Attribute, List<Object>>();
 
-                    for (Field field : fields)
-                    {
-                        if (!ReflectUtils.isTransientOrStatic(field))
-                        {
+                    for (Field field : fields) {
+                        if (!ReflectUtils.isTransientOrStatic(field)) {
                             extractCompositeKey(metaModel, keyObj, builder, translator, value, useInClause,
-                                    columnValues, field);
+                                columnValues, field);
                         }
                     }
 
                     // Composite key always contains clusterKey.
                     allowFiltering = true;
-                    if (useInClause)
-                    {
-                        for (Attribute columnAttribute : columnValues.keySet())
-                        {
+                    if (useInClause) {
+                        for (Attribute columnAttribute : columnValues.keySet()) {
                             isPresent = appendInClause(builder, translator, columnValues.get(columnAttribute),
-                                    ((AbstractAttribute) columnAttribute).getBindableJavaType(),
-                                    ((AbstractAttribute) columnAttribute).getJPAColumnName(), isPresent);
+                                ((AbstractAttribute) columnAttribute).getBindableJavaType(),
+                                ((AbstractAttribute) columnAttribute).getJPAColumnName(), isPresent);
                         }
                     }
-                }
-                else if (keyObj != null && metaModel.isEmbeddable(m.getIdAttribute().getBindableJavaType())
-                        && StringUtils.contains(fieldName, '.'))
-                {
+                } else if (keyObj != null && metaModel.isEmbeddable(m.getIdAttribute().getBindableJavaType())
+                    && StringUtils.contains(fieldName, '.')) {
                     // Means it is a case of composite column.
                     isPresent = getCompoundKeyColumn(metaModel, keyObj, builder, isPresent, translator, fieldName,
-                            condition, value, useInClause);
+                        condition, value, useInClause);
 
                     allowFiltering = true;
-                }
-                else if (idColumn.equals(fieldName))
-                {
+                } else if (idColumn.equals(fieldName)) {
                     // dont use token for equals query on id column (#856)
                     boolean useToken = use;
-                    if (condition.equals("="))
-                    {
+                    if (condition.equals("=")) {
                         useToken = false;
                     }
                     isPresent = buildWhereClause(builder, isPresent, translator, condition, value, useInClause,
-                            ((AbstractAttribute) m.getIdAttribute()), CassandraUtilities.getIdColumnName(
-                                    kunderaMetadata, m, externalProperties,
-                                    ((CassandraClientBase) persistenceDelegeator.getClient(m)).isCql3Enabled(m)),
-                            useToken);
-                }
-                else
-                {
+                        ((AbstractAttribute) m.getIdAttribute()),
+                        CassandraUtilities.getIdColumnName(kunderaMetadata, m, externalProperties,
+                            ((CassandraClientBase) persistenceDelegeator.getClient(m)).isCql3Enabled(m)),
+                        useToken);
+                } else {
                     EntityType entity = metaModel.entity(m.getEntityClazz());
                     // Metamodel metamodel =
                     // KunderaMetadataManager.getMetamodel(kunderaMetadata,
                     // m.getPersistenceUnit());
                     String discriminatorColumn = ((AbstractManagedType) entity).getDiscriminatorColumn();
-                    if (fieldName.equals(discriminatorColumn))
-                    {
+                    if (fieldName.equals(discriminatorColumn)) {
                         translator.buildWhereClause(builder, String.class, fieldName,
-                                value.isEmpty() ? null : value.get(0), condition, false);
+                            value.isEmpty() ? null : value.get(0), condition, false);
                         isPresent = true;
 
-                    }
-                    else
-                    {
-                        Metamodel metamodel = KunderaMetadataManager.getMetamodel(kunderaMetadata,
-                                m.getPersistenceUnit());
+                    } else {
+                        Metamodel metamodel =
+                            KunderaMetadataManager.getMetamodel(kunderaMetadata, m.getPersistenceUnit());
                         Attribute attribute = ((MetamodelImpl) metamodel).getEntityAttribute(m.getEntityClazz(),
-                                m.getFieldName(fieldName));
+                            m.getFieldName(fieldName));
 
                         isPresent = buildWhereClause(builder, isPresent, translator, condition, value, useInClause,
-                                ((AbstractAttribute) attribute), fieldName, false);
+                            ((AbstractAttribute) attribute), fieldName, false);
                     }
 
                     allowFiltering = true;
@@ -939,22 +780,18 @@ public class CassQuery extends QueryImpl
         }
 
         // Strip last AND clause.
-        if (isPresent)
-        {
+        if (isPresent) {
             builder.delete(builder.lastIndexOf(CQLTranslator.AND_CLAUSE), builder.length());
         }
 
         // Append order by clause into query
         builder = appendOrderByClause(metaModel, m, keyObj, builder, translator);
 
-        if (allowFiltering && use)
-        {
+        if (allowFiltering && use) {
             onLimit(builder);
             builder.append(" ");
             translator.buildFilteringClause(builder);
-        }
-        else if (use)
-        {
+        } else if (use) {
             onLimit(builder);
         }
 
@@ -985,15 +822,13 @@ public class CassQuery extends QueryImpl
      * @return the compound key column
      */
     private boolean getCompoundKeyColumn(MetamodelImpl metamodel, EmbeddableType keyObj, StringBuilder builder,
-            boolean isPresent, CQLTranslator translator, String fieldName, String condition, List<Object> value,
-            boolean useInClause)
-    {
+        boolean isPresent, CQLTranslator translator, String fieldName, String condition, List<Object> value,
+        boolean useInClause) {
         fieldName = fieldName.substring(fieldName.indexOf(".") + 1);
 
         // If partition key part age given in query, i.e. restriction on
         // id.compositekey.compositePartitionkey.partitionkeyColumn.
-        if (fieldName.indexOf(".") > 0)
-        {
+        if (fieldName.indexOf(".") > 0) {
             String compositePartitionkeyName = fieldName.substring(0, fieldName.indexOf("."));
             AbstractAttribute attribute = (AbstractAttribute) keyObj.getAttribute(compositePartitionkeyName);
             fieldName = fieldName.substring(fieldName.indexOf(".") + 1);
@@ -1005,42 +840,36 @@ public class CassQuery extends QueryImpl
             String columnName = attribute.getJPAColumnName();
 
             isPresent = buildWhereClause(builder, isPresent, translator, condition, value, useInClause, attribute,
-                    columnName, false);
+                columnName, false);
         }
         // if composite partition key object is given in query, i.e. restriction
         // on id.compositekey.compositePartitionkey
-        else if (metamodel.isEmbeddable(((AbstractAttribute) keyObj.getAttribute(fieldName)).getBindableJavaType()))
-        {
+        else if (metamodel.isEmbeddable(((AbstractAttribute) keyObj.getAttribute(fieldName)).getBindableJavaType())) {
             AbstractAttribute attribute = (AbstractAttribute) keyObj.getAttribute(fieldName);
             Set<Attribute> attributes = metamodel.embeddable(attribute.getBindableJavaType()).getAttributes();
 
-            if (!useInClause)
-            {
+            if (!useInClause) {
                 // Iterating and appending each column of composite partition
                 // key in query builder.
-                for (Attribute nestedAttribute : attributes)
-                {
+                for (Attribute nestedAttribute : attributes) {
                     String columnName = ((AbstractAttribute) nestedAttribute).getJPAColumnName();
                     Object valueObject = PropertyAccessorHelper.getObject(value.isEmpty() ? null : value.get(0),
-                            (Field) nestedAttribute.getJavaMember());
+                        (Field) nestedAttribute.getJavaMember());
                     translator.buildWhereClause(builder, nestedAttribute.getJavaType(), columnName, valueObject,
-                            condition, false);
+                        condition, false);
                 }
-            }
-            else
-            {
+            } else {
                 throw new IllegalArgumentException("In clause is not supported on first part of partition key.");
             }
             isPresent = true;
         }
         // if Not a composite partition key,
         // id.compositekey.partitionkey/clusterKey.
-        else
-        {
+        else {
             AbstractAttribute attribute = (AbstractAttribute) keyObj.getAttribute(fieldName);
             String columnName = attribute.getJPAColumnName();
             isPresent = buildWhereClause(builder, isPresent, translator, condition, value, useInClause, attribute,
-                    columnName, false);
+                columnName, false);
         }
         return isPresent;
     }
@@ -1061,36 +890,30 @@ public class CassQuery extends QueryImpl
      * @return the string builder
      */
     private StringBuilder appendOrderByClause(MetamodelImpl metaModel, EntityMetadata m, EmbeddableType keyObj,
-            StringBuilder builder, CQLTranslator translator)
-    {
+        StringBuilder builder, CQLTranslator translator) {
         List<SortOrdering> orders = getKunderaQuery().getOrdering();
 
-        if (orders != null)
-        {
+        if (orders != null) {
             builder.append(CQLTranslator.SPACE_STRING);
             builder.append(CQLTranslator.SORT_CLAUSE);
 
-            for (SortOrdering order : orders)
-            {
+            for (SortOrdering order : orders) {
                 String orderColumnName = order.getColumnName();
 
                 orderColumnName = orderColumnName.substring(orderColumnName.indexOf(".") + 1, orderColumnName.length());
 
                 String orderByColumnName;
 
-                if (StringUtils.contains(orderColumnName, '.'))
-                {
+                if (StringUtils.contains(orderColumnName, '.')) {
                     String propertyName = orderColumnName.substring(0, orderColumnName.indexOf("."));
                     Attribute embeddableAttribute = metaModel.getEntityAttribute(m.getEntityClazz(), propertyName);
-                    EmbeddableType embeddableType = metaModel.embeddable(((AbstractAttribute) embeddableAttribute)
-                            .getBindableJavaType());
+                    EmbeddableType embeddableType =
+                        metaModel.embeddable(((AbstractAttribute) embeddableAttribute).getBindableJavaType());
                     orderColumnName = orderColumnName.substring(orderColumnName.indexOf(".") + 1);
                     AbstractAttribute attribute = (AbstractAttribute) embeddableType.getAttribute(orderColumnName);
                     orderByColumnName = attribute.getJPAColumnName();
 
-                }
-                else
-                {
+                } else {
                     Attribute attribute = metaModel.getEntityAttribute(m.getEntityClazz(), orderColumnName);
                     orderByColumnName = ((AbstractAttribute) attribute).getJPAColumnName();
                 }
@@ -1101,8 +924,7 @@ public class CassQuery extends QueryImpl
                 builder.append(CQLTranslator.COMMA_STR);
             }
 
-            if (!orders.isEmpty())
-            {
+            if (!orders.isEmpty()) {
                 builder.deleteCharAt(builder.lastIndexOf(CQLTranslator.COMMA_STR));
             }
         }
@@ -1131,78 +953,63 @@ public class CassQuery extends QueryImpl
      * @return true, if successful
      */
     private boolean extractCompositeKey(MetamodelImpl metaModel, EmbeddableType keyObj, StringBuilder builder,
-            CQLTranslator translator, List<Object> value, boolean useInClause,
-            Map<Attribute, List<Object>> columnValues, Field field)
-    {
+        CQLTranslator translator, List<Object> value, boolean useInClause, Map<Attribute, List<Object>> columnValues,
+        Field field) {
         Attribute compositeColumn = keyObj.getAttribute(field.getName());
         String jpaColumnName = ((AbstractAttribute) compositeColumn).getJPAColumnName();
 
-        if (useInClause)
-        {
-            for (Object embeddedObject : value)
-            {
+        if (useInClause) {
+            for (Object embeddedObject : value) {
 
                 Object valueObject = PropertyAccessorHelper.getObject(embeddedObject, field);
                 // Checking for composite partition key.
-                if (metaModel.isEmbeddable(((AbstractAttribute) compositeColumn).getBindableJavaType()))
-                {
-                    Set<Attribute> attributes = metaModel.embeddable(
-                            ((AbstractAttribute) compositeColumn).getBindableJavaType()).getAttributes();
+                if (metaModel.isEmbeddable(((AbstractAttribute) compositeColumn).getBindableJavaType())) {
+                    Set<Attribute> attributes = metaModel
+                        .embeddable(((AbstractAttribute) compositeColumn).getBindableJavaType()).getAttributes();
 
                     // Iterating over composite partition key columns.
-                    for (Attribute nestedAttribute : attributes)
-                    {
+                    for (Attribute nestedAttribute : attributes) {
                         List<Object> valueList = columnValues.get(compositeColumn);
 
-                        if (valueList == null)
-                        {
+                        if (valueList == null) {
                             valueList = new ArrayList<Object>();
                         }
 
-                        Object obj = PropertyAccessorHelper.getObject(valueObject,
-                                (Field) nestedAttribute.getJavaMember());
+                        Object obj =
+                            PropertyAccessorHelper.getObject(valueObject, (Field) nestedAttribute.getJavaMember());
                         valueList.add(obj);
                         columnValues.put(nestedAttribute, valueList);
                     }
-                }
-                else
-                {
+                } else {
                     List<Object> valueList = columnValues.get(compositeColumn);
 
-                    if (valueList == null)
-                    {
+                    if (valueList == null) {
                         valueList = new ArrayList<Object>();
                     }
                     valueList.add(valueObject);
                     columnValues.put(compositeColumn, valueList);
                 }
             }
-        }
-        else
-        {
+        } else {
             Object valueObject = PropertyAccessorHelper.getObject(value.isEmpty() ? null : value.get(0), field);
 
             // Checking for composite partition key.
-            if (metaModel.isEmbeddable(((AbstractAttribute) compositeColumn).getBindableJavaType()))
-            {
-                Set<Attribute> attributes = metaModel.embeddable(
-                        ((AbstractAttribute) compositeColumn).getBindableJavaType()).getAttributes();
+            if (metaModel.isEmbeddable(((AbstractAttribute) compositeColumn).getBindableJavaType())) {
+                Set<Attribute> attributes =
+                    metaModel.embeddable(((AbstractAttribute) compositeColumn).getBindableJavaType()).getAttributes();
 
                 // Iterating over composite partition key columns.
-                for (Attribute nestedAttribute : attributes)
-                {
+                for (Attribute nestedAttribute : attributes) {
                     String columnName = ((AbstractAttribute) nestedAttribute).getJPAColumnName();
                     Object obj = PropertyAccessorHelper.getObject(valueObject, (Field) nestedAttribute.getJavaMember());
                     translator.buildWhereClause(builder, nestedAttribute.getJavaType(), columnName, obj,
-                            CQLTranslator.EQ_CLAUSE, false);
+                        CQLTranslator.EQ_CLAUSE, false);
                 }
                 // returning true because builder has AND clause at end.
                 return true;
-            }
-            else
-            {
+            } else {
                 translator.buildWhereClause(builder, field.getType(), jpaColumnName, valueObject,
-                        CQLTranslator.EQ_CLAUSE, false);
+                    CQLTranslator.EQ_CLAUSE, false);
                 // returning true because builder has AND clause at end.
                 return true;
             }
@@ -1235,28 +1042,23 @@ public class CassQuery extends QueryImpl
      * @return true, if successful
      */
     private boolean buildWhereClause(StringBuilder builder, boolean isPresent, CQLTranslator translator,
-            String condition, List<Object> value, boolean useInClause, AbstractAttribute idAttributeColumn,
-            String columnName, boolean useToken)
-    {
-        if (value.isEmpty())
-        {
+        String condition, List<Object> value, boolean useInClause, AbstractAttribute idAttributeColumn,
+        String columnName, boolean useToken) {
+        if (value.isEmpty()) {
             isPresent = appendIn(builder, translator, columnName);
             builder.append("( )");
             builder.append(" AND ");
         }
         // handle relations in Id
-        else if (useInClause && value.size() > 1)
-        {
+        else if (useInClause && value.size() > 1) {
             isPresent = appendInClause(builder, translator, value, idAttributeColumn.getBindableJavaType(), columnName,
-                    isPresent);
-        }
-        else
-        {
+                isPresent);
+        } else {
             // TODO for partition key in case of embedded key.
             // idAttributeColumn.getBindableJavaType() was sending this class,
             // changed to getJavaType()
             translator.buildWhereClause(builder, ((Attribute) idAttributeColumn).getJavaType(), columnName,
-                    value.isEmpty() ? null : value.get(0), condition, useToken);
+                value.isEmpty() ? null : value.get(0), condition, useToken);
         }
         return isPresent;
     }
@@ -1272,8 +1074,7 @@ public class CassQuery extends QueryImpl
      *            the column name
      * @return true, if successful
      */
-    private boolean appendIn(StringBuilder builder, CQLTranslator translator, String columnName)
-    {
+    private boolean appendIn(StringBuilder builder, CQLTranslator translator, String columnName) {
         boolean isPresent;
         isPresent = true;
         translator.ensureCase(builder, columnName, false);
@@ -1299,12 +1100,10 @@ public class CassQuery extends QueryImpl
      * @return true, if successful
      */
     private boolean appendInClause(StringBuilder queryBuilder, CQLTranslator translator, List<Object> value,
-            Class fieldClazz, String columnName, boolean isPresent)
-    {
+        Class fieldClazz, String columnName, boolean isPresent) {
         isPresent = appendIn(queryBuilder, translator, columnName);
         queryBuilder.append("(");
-        for (Object objectvalue : value)
-        {
+        for (Object objectvalue : value) {
             translator.appendValue(queryBuilder, fieldClazz, objectvalue, isPresent, false);
             queryBuilder.append(", ");
         }
@@ -1322,10 +1121,8 @@ public class CassQuery extends QueryImpl
      * @param builder
      *            the builder
      */
-    void addWhereClause(StringBuilder builder)
-    {
-        if (!getKunderaQuery().getFilterClauseQueue().isEmpty())
-        {
+    void addWhereClause(StringBuilder builder) {
+        if (!getKunderaQuery().getFilterClauseQueue().isEmpty()) {
             builder.append(CQLTranslator.ADD_WHERE_CLAUSE);
         }
     }
@@ -1336,8 +1133,7 @@ public class CassQuery extends QueryImpl
      * @see com.impetus.kundera.query.QueryImpl#close()
      */
     @Override
-    public void close()
-    {
+    public void close() {
         // Nothing to close.
     }
 
@@ -1347,23 +1143,20 @@ public class CassQuery extends QueryImpl
      * @see com.impetus.kundera.query.QueryImpl#iterate()
      */
     @Override
-    public Iterator iterate()
-    {
-        if (kunderaQuery.isNative())
-        {
+    public Iterator iterate() {
+        if (kunderaQuery.isNative()) {
             throw new UnsupportedOperationException("Iteration not supported over native queries");
         }
         EntityMetadata m = getEntityMetadata();
         Client client = persistenceDelegeator.getClient(m);
         externalProperties = ((CassandraClientBase) client).getExternalProperties();
 
-        if (!MetadataUtils.useSecondryIndex(((ClientBase) client).getClientMetadata()))
-        {
+        if (!MetadataUtils.useSecondryIndex(((ClientBase) client).getClientMetadata())) {
             throw new UnsupportedOperationException("Scrolling over cassandra is unsupported for lucene queries");
         }
 
         return new ResultIterator(this, m, persistenceDelegeator.getClient(m), this.getReader(),
-                getFetchSize() != null ? getFetchSize() : this.maxResult, kunderaMetadata);
+            getFetchSize() != null ? getFetchSize() : this.maxResult, kunderaMetadata);
     }
 
     /**
@@ -1376,8 +1169,7 @@ public class CassQuery extends QueryImpl
      * @param m
      *            the m
      */
-    public void setRelationalEntities(List enhanceEntities, Client client, EntityMetadata m)
-    {
+    public void setRelationalEntities(List enhanceEntities, Client client, EntityMetadata m) {
         super.setRelationEntities(enhanceEntities, client, m);
     }
 
@@ -1388,29 +1180,26 @@ public class CassQuery extends QueryImpl
      *            the kundera query
      * @return the string
      */
-    public String createUpdateQuery(KunderaQuery kunderaQuery)
-    {
+    public String createUpdateQuery(KunderaQuery kunderaQuery) {
         EntityMetadata metadata = kunderaQuery.getEntityMetadata();
-        MetamodelImpl metaModel = (MetamodelImpl) kunderaMetadata.getApplicationMetadata().getMetamodel(
-                metadata.getPersistenceUnit());
+        MetamodelImpl metaModel =
+            (MetamodelImpl) kunderaMetadata.getApplicationMetadata().getMetamodel(metadata.getPersistenceUnit());
 
         CQLTranslator translator = new CQLTranslator();
         String update_Query = translator.UPDATE_QUERY;
 
         String tableName = metadata.getTableName();
         update_Query = StringUtils.replace(update_Query, CQLTranslator.COLUMN_FAMILY,
-                translator.ensureCase(new StringBuilder(), tableName, false).toString());
+            translator.ensureCase(new StringBuilder(), tableName, false).toString());
 
         StringBuilder builder = new StringBuilder(update_Query);
 
-        Object ttlColumns = ((CassandraClientBase) persistenceDelegeator.getClient(metadata)).getTtlValues().get(
-                metadata.getTableName());
+        Object ttlColumns = ((CassandraClientBase) persistenceDelegeator.getClient(metadata)).getTtlValues()
+            .get(metadata.getTableName());
 
-        if ((ttlColumns != null && ttlColumns instanceof Integer) || this.ttl != null)
-        {
+        if ((ttlColumns != null && ttlColumns instanceof Integer) || this.ttl != null) {
             int ttl = this.ttl != null ? this.ttl : ((Integer) ttlColumns).intValue();
-            if (ttl != 0)
-            {
+            if (ttl != 0) {
                 builder.append(" USING TTL ");
                 builder.append(ttl);
                 builder.append(" ");
@@ -1419,8 +1208,7 @@ public class CassQuery extends QueryImpl
 
         builder.append(CQLTranslator.ADD_SET_CLAUSE);
 
-        for (UpdateClause updateClause : kunderaQuery.getUpdateClauseQueue())
-        {
+        for (UpdateClause updateClause : kunderaQuery.getUpdateClauseQueue()) {
 
             String property = updateClause.getProperty();
 
@@ -1436,13 +1224,10 @@ public class CassQuery extends QueryImpl
         Class compoundKeyClass = metadata.getIdAttribute().getBindableJavaType();
         EmbeddableType compoundKey = null;
         String idColumn;
-        if (metaModel.isEmbeddable(compoundKeyClass))
-        {
+        if (metaModel.isEmbeddable(compoundKeyClass)) {
             compoundKey = metaModel.embeddable(compoundKeyClass);
             idColumn = ((AbstractAttribute) metadata.getIdAttribute()).getJPAColumnName();
-        }
-        else
-        {
+        } else {
             idColumn = ((AbstractAttribute) metadata.getIdAttribute()).getJPAColumnName();
         }
 
@@ -1458,17 +1243,16 @@ public class CassQuery extends QueryImpl
      *            the kundera query
      * @return the string
      */
-    public String createDeleteQuery(KunderaQuery kunderaQuery)
-    {
+    public String createDeleteQuery(KunderaQuery kunderaQuery) {
         EntityMetadata metadata = kunderaQuery.getEntityMetadata();
-        MetamodelImpl metaModel = (MetamodelImpl) kunderaMetadata.getApplicationMetadata().getMetamodel(
-                metadata.getPersistenceUnit());
+        MetamodelImpl metaModel =
+            (MetamodelImpl) kunderaMetadata.getApplicationMetadata().getMetamodel(metadata.getPersistenceUnit());
         CQLTranslator translator = new CQLTranslator();
         String delete_query = translator.DELETE_QUERY;
 
         String tableName = kunderaQuery.getEntityMetadata().getTableName();
         delete_query = StringUtils.replace(delete_query, CQLTranslator.COLUMN_FAMILY,
-                translator.ensureCase(new StringBuilder(), tableName, false).toString());
+            translator.ensureCase(new StringBuilder(), tableName, false).toString());
 
         StringBuilder builder = new StringBuilder(delete_query);
         builder.append(CQLTranslator.ADD_WHERE_CLAUSE);
@@ -1476,13 +1260,10 @@ public class CassQuery extends QueryImpl
         Class compoundKeyClass = metadata.getIdAttribute().getBindableJavaType();
         EmbeddableType compoundKey = null;
         String idColumn;
-        if (metaModel.isEmbeddable(compoundKeyClass))
-        {
+        if (metaModel.isEmbeddable(compoundKeyClass)) {
             compoundKey = metaModel.embeddable(compoundKeyClass);
             idColumn = ((AbstractAttribute) metadata.getIdAttribute()).getJPAColumnName();
-        }
-        else
-        {
+        } else {
             idColumn = ((AbstractAttribute) metadata.getIdAttribute()).getJPAColumnName();
         }
 
@@ -1506,38 +1287,30 @@ public class CassQuery extends QueryImpl
      *            the builder
      */
     private void buildWhereClause(KunderaQuery kunderaQuery, EntityMetadata metadata, MetamodelImpl metaModel,
-            CQLTranslator translator, StringBuilder builder)
-    {
-        for (Object clause : kunderaQuery.getFilterClauseQueue())
-        {
+        CQLTranslator translator, StringBuilder builder) {
+        for (Object clause : kunderaQuery.getFilterClauseQueue()) {
             FilterClause filterClause = (FilterClause) clause;
             Field f = (Field) metaModel.entity(metadata.getEntityClazz())
-                    .getAttribute(metadata.getFieldName(filterClause.getProperty())).getJavaMember();
+                .getAttribute(metadata.getFieldName(filterClause.getProperty())).getJavaMember();
             String jpaColumnName = getColumnName(metadata, filterClause.getProperty());
 
-            if (metaModel.isEmbeddable(metadata.getIdAttribute().getBindableJavaType()))
-            {
+            if (metaModel.isEmbeddable(metadata.getIdAttribute().getBindableJavaType())) {
                 Field[] fields = metadata.getIdAttribute().getBindableJavaType().getDeclaredFields();
                 EmbeddableType compoundKey = metaModel.embeddable(metadata.getIdAttribute().getBindableJavaType());
-                for (Field field : fields)
-                {
+                for (Field field : fields) {
                     if (field != null && !Modifier.isStatic(field.getModifiers())
-                            && !Modifier.isTransient(field.getModifiers())
-                            && !field.isAnnotationPresent(Transient.class))
-                    {
+                        && !Modifier.isTransient(field.getModifiers()) && !field.isAnnotationPresent(Transient.class)) {
                         Attribute attribute = compoundKey.getAttribute(field.getName());
                         String columnName = ((AbstractAttribute) attribute).getJPAColumnName();
                         Object value = PropertyAccessorHelper.getObject(filterClause.getValue().get(0), field);
                         // TODO
                         translator.buildWhereClause(builder, field.getType(), columnName, value,
-                                filterClause.getCondition(), false);
+                            filterClause.getCondition(), false);
                     }
                 }
-            }
-            else
-            {
+            } else {
                 translator.buildWhereClause(builder, f.getType(), jpaColumnName, filterClause.getValue().get(0),
-                        filterClause.getCondition(), false);
+                    filterClause.getCondition(), false);
             }
         }
         builder.delete(builder.lastIndexOf(CQLTranslator.AND_CLAUSE), builder.length());
@@ -1552,22 +1325,18 @@ public class CassQuery extends QueryImpl
      *            the property
      * @return the column name
      */
-    private String getColumnName(EntityMetadata metadata, String property)
-    {
-        MetamodelImpl metaModel = (MetamodelImpl) kunderaMetadata.getApplicationMetadata().getMetamodel(
-                metadata.getPersistenceUnit());
+    private String getColumnName(EntityMetadata metadata, String property) {
+        MetamodelImpl metaModel =
+            (MetamodelImpl) kunderaMetadata.getApplicationMetadata().getMetamodel(metadata.getPersistenceUnit());
         String jpaColumnName = null;
 
-        if (property.equals(((AbstractAttribute) metadata.getIdAttribute()).getJPAColumnName()))
-        {
+        if (property.equals(((AbstractAttribute) metadata.getIdAttribute()).getJPAColumnName())) {
             jpaColumnName = CassandraUtilities.getIdColumnName(kunderaMetadata, metadata,
-                    ((CassandraClientBase) persistenceDelegeator.getClient(metadata)).getExternalProperties(),
-                    ((CassandraClientBase) persistenceDelegeator.getClient(metadata)).isCql3Enabled(metadata));
-        }
-        else
-        {
+                ((CassandraClientBase) persistenceDelegeator.getClient(metadata)).getExternalProperties(),
+                ((CassandraClientBase) persistenceDelegeator.getClient(metadata)).isCql3Enabled(metadata));
+        } else {
             jpaColumnName = ((AbstractAttribute) metaModel.getEntityAttribute(metadata.getEntityClazz(), property))
-                    .getJPAColumnName();
+                .getJPAColumnName();
         }
         return jpaColumnName;
     }
@@ -1577,8 +1346,7 @@ public class CassQuery extends QueryImpl
      * 
      * @return true, if is native
      */
-    boolean isNative()
-    {
+    boolean isNative() {
         return kunderaQuery.isNative();
     }
 

--- a/src/kundera-cassandra/cassandra-ds-driver/src/main/java/com/impetus/kundera/client/cassandra/dsdriver/DSClient.java
+++ b/src/kundera-cassandra/cassandra-ds-driver/src/main/java/com/impetus/kundera/client/cassandra/dsdriver/DSClient.java
@@ -854,7 +854,7 @@ public class DSClient extends CassandraClientBase implements Client<DSCassQuery>
 						);
 					else
 						boundStatement.setString(
-							value.getIndex(),
+							value.getIndex() - 1,
 							(String) value.getValue()
 						);
 				} else if (value.getValue() instanceof Integer) {
@@ -865,7 +865,7 @@ public class DSClient extends CassandraClientBase implements Client<DSCassQuery>
 						);
 					else
 						boundStatement.setInt(
-							value.getIndex(),
+							value.getIndex() - 1,
 							(Integer) value.getValue()
 						);
 				} else if (value.getValue() instanceof Long) {
@@ -876,7 +876,7 @@ public class DSClient extends CassandraClientBase implements Client<DSCassQuery>
 						);
 					else
 						boundStatement.setLong(
-							value.getIndex(),
+							value.getIndex() - 1,
 							(Long) value.getValue()
 						);
 				} else if (value.getValue() instanceof java.util.UUID) {
@@ -887,7 +887,7 @@ public class DSClient extends CassandraClientBase implements Client<DSCassQuery>
 						);
 					else
 						boundStatement.setUUID(
-							value.getIndex(),
+							value.getIndex() - 1,
 							(java.util.UUID) value.getValue()
 						);
 				} else if (value.getValue() instanceof List) {
@@ -898,7 +898,7 @@ public class DSClient extends CassandraClientBase implements Client<DSCassQuery>
 						);
 					else
 						boundStatement.setList(
-							value.getIndex(),
+							value.getIndex() - 1,
 							(List) value.getValue()
 						);
 				} else {

--- a/src/kundera-cassandra/cassandra-ds-driver/src/main/java/com/impetus/kundera/client/cassandra/dsdriver/DSClient.java
+++ b/src/kundera-cassandra/cassandra-ds-driver/src/main/java/com/impetus/kundera/client/cassandra/dsdriver/DSClient.java
@@ -84,8 +84,7 @@ import com.impetus.kundera.query.KunderaQuery;
  * @author vivek.mishra
  * 
  */
-public class DSClient extends CassandraClientBase implements Client<DSCassQuery>, Batcher
-{
+public class DSClient extends CassandraClientBase implements Client<DSCassQuery>, Batcher {
 
     /** log for this class. */
     private static Logger log = LoggerFactory.getLogger(DSClient.class);
@@ -113,8 +112,7 @@ public class DSClient extends CassandraClientBase implements Client<DSCassQuery>
      *            the generator
      */
     public DSClient(DSClientFactory factory, String persistenceUnit, Map<String, Object> externalProperties,
-            KunderaMetadata kunderaMetadata, EntityReader reader, final TimestampGenerator generator)
-    {
+        KunderaMetadata kunderaMetadata, EntityReader reader, final TimestampGenerator generator) {
         super(persistenceUnit, externalProperties, kunderaMetadata, generator);
         this.factory = factory;
         this.reader = reader;
@@ -125,32 +123,22 @@ public class DSClient extends CassandraClientBase implements Client<DSCassQuery>
     /*
      * (non-Javadoc)
      * 
-     * @see
-     * com.impetus.kundera.client.ClientBase#onPersist(com.impetus.kundera.metadata
-     * .model.EntityMetadata, java.lang.Object, java.lang.Object,
-     * java.util.List)
+     * @see com.impetus.kundera.client.ClientBase#onPersist(com.impetus.kundera.metadata .model.EntityMetadata,
+     * java.lang.Object, java.lang.Object, java.util.List)
      */
     @Override
-    protected void onPersist(EntityMetadata entityMetadata, Object entity, Object id, List<RelationHolder> rlHolders)
-    {
+    protected void onPersist(EntityMetadata entityMetadata, Object entity, Object id, List<RelationHolder> rlHolders) {
         // Insert, update is fine
-        try
-        {
-            cqlClient.persist(entityMetadata, entity, null, rlHolders, getTtlValues()
-                    .get(entityMetadata.getTableName()));
-        }
-        catch (InvalidRequestException e)
-        {
+        try {
+            cqlClient.persist(entityMetadata, entity, null, rlHolders,
+                getTtlValues().get(entityMetadata.getTableName()));
+        } catch (InvalidRequestException e) {
             log.error("Error while persisting record, Caused by: .", e);
             throw new KunderaException(e);
-        }
-        catch (TException e)
-        {
+        } catch (TException e) {
             log.error("Error while persisting record, Caused by: .", e);
             throw new KunderaException(e);
-        }
-        catch (UnsupportedEncodingException e)
-        {
+        } catch (UnsupportedEncodingException e) {
             log.error("Error while persisting record, Caused by: .", e);
             throw new KunderaException(e);
         }
@@ -167,8 +155,7 @@ public class DSClient extends CassandraClientBase implements Client<DSCassQuery>
      * @return the object
      */
     @Override
-    public Object find(Class entityClass, Object rowId)
-    {
+    public Object find(Class entityClass, Object rowId) {
         EntityMetadata metadata = KunderaMetadataManager.getEntityMetadata(kunderaMetadata, entityClass);
         StringBuilder builder = createSelectQuery(rowId, metadata, metadata.getTableName());
         ResultSet rSet = this.execute(builder.toString(), null);
@@ -187,16 +174,15 @@ public class DSClient extends CassandraClientBase implements Client<DSCassQuery>
      *            the table name
      * @return the string builder
      */
-    private StringBuilder createSelectQuery(Object rowId, EntityMetadata metadata, String tableName)
-    {
-        MetamodelImpl metaModel = (MetamodelImpl) kunderaMetadata.getApplicationMetadata().getMetamodel(
-                metadata.getPersistenceUnit());
+    private StringBuilder createSelectQuery(Object rowId, EntityMetadata metadata, String tableName) {
+        MetamodelImpl metaModel =
+            (MetamodelImpl) kunderaMetadata.getApplicationMetadata().getMetamodel(metadata.getPersistenceUnit());
 
         CQLTranslator translator = new CQLTranslator();
 
         String select_Query = translator.SELECTALL_QUERY;
         select_Query = StringUtils.replace(select_Query, CQLTranslator.COLUMN_FAMILY,
-                translator.ensureCase(new StringBuilder(), tableName, false).toString());
+            translator.ensureCase(new StringBuilder(), tableName, false).toString());
         StringBuilder builder = new StringBuilder(select_Query);
 
         builder.append(CQLTranslator.ADD_WHERE_CLAUSE);
@@ -209,24 +195,19 @@ public class DSClient extends CassandraClientBase implements Client<DSCassQuery>
     /*
      * (non-Javadoc)
      * 
-     * @see
-     * com.impetus.client.cassandra.CassandraClientBase#findAll(java.lang.Class,
-     * java.lang.String[], java.lang.Object[])
+     * @see com.impetus.client.cassandra.CassandraClientBase#findAll(java.lang.Class, java.lang.String[],
+     * java.lang.Object[])
      */
     @Override
-    public final <E> List<E> findAll(Class<E> entityClass, String[] columnsToSelect, Object... rowIds)
-    {
+    public final <E> List<E> findAll(Class<E> entityClass, String[] columnsToSelect, Object... rowIds) {
         // TODO: need to think about selected column case.
         // Bring in IN Clause in place of each read.
 
         List results = new ArrayList<E>();
-        if (rowIds != null)
-        {
-            for (Object rowId : rowIds)
-            {
+        if (rowIds != null) {
+            for (Object rowId : rowIds) {
                 Object result = find(entityClass, rowId);
-                if (result != null)
-                {
+                if (result != null) {
                     results.add(result);
                 }
             }
@@ -237,33 +218,29 @@ public class DSClient extends CassandraClientBase implements Client<DSCassQuery>
     /*
      * (non-Javadoc)
      * 
-     * @see com.impetus.kundera.client.Client#find(java.lang.Class,
-     * java.util.Map)
+     * @see com.impetus.kundera.client.Client#find(java.lang.Class, java.util.Map)
      */
     @Override
-    public <E> List<E> find(Class<E> entityClass, Map<String, String> embeddedColumnMap)
-    {
+    public <E> List<E> find(Class<E> entityClass, Map<String, String> embeddedColumnMap) {
         throw new UnsupportedOperationException(
-                "Support for super columns is not available with DS java driver. Either use Thrift or pelops for the same");
+            "Support for super columns is not available with DS java driver. Either use Thrift or pelops for the same");
     }
 
     /*
      * (non-Javadoc)
      * 
-     * @see
-     * com.impetus.kundera.client.Client#persistJoinTable(com.impetus.kundera
+     * @see com.impetus.kundera.client.Client#persistJoinTable(com.impetus.kundera
      * .persistence.context.jointable.JoinTableData)
      */
     @Override
-    public void persistJoinTable(JoinTableData joinTableData)
-    {
+    public void persistJoinTable(JoinTableData joinTableData) {
         // TODO:: Add support for Many-to-Many join tables.
         String joinTableName = joinTableData.getJoinTableName();
         String invJoinColumnName = joinTableData.getInverseJoinColumnName();
         Map<Object, Set<Object>> joinTableRecords = joinTableData.getJoinTableRecords();
 
-        EntityMetadata entityMetadata = KunderaMetadataManager.getEntityMetadata(kunderaMetadata,
-                joinTableData.getEntityClass());
+        EntityMetadata entityMetadata =
+            KunderaMetadataManager.getEntityMetadata(kunderaMetadata, joinTableData.getEntityClass());
 
         // need to bring in an insert query for this
         // add columns & execute query
@@ -282,7 +259,7 @@ public class DSClient extends CassandraClientBase implements Client<DSCassQuery>
         builder.append(translator.ensureCase(new StringBuilder(), joinTableData.getInverseJoinColumnName(), false));
 
         insert_Query = StringUtils.replace(insert_Query, CQLTranslator.COLUMN_FAMILY,
-                translator.ensureCase(new StringBuilder(), joinTableName, false).toString());
+            translator.ensureCase(new StringBuilder(), joinTableName, false).toString());
 
         insert_Query = StringUtils.replace(insert_Query, CQLTranslator.COLUMNS, builder.toString());
 
@@ -291,37 +268,33 @@ public class DSClient extends CassandraClientBase implements Client<DSCassQuery>
         StringBuilder statements = new StringBuilder();
 
         // insert query for each row key and
-        for (Object key : joinTableRecords.keySet())
-        {
-            PropertyAccessor accessor = PropertyAccessorFactory.getPropertyAccessor((Field) entityMetadata
-                    .getIdAttribute().getJavaMember());
+        for (Object key : joinTableRecords.keySet()) {
+            PropertyAccessor accessor =
+                PropertyAccessorFactory.getPropertyAccessor((Field) entityMetadata.getIdAttribute().getJavaMember());
 
             Set<Object> values = joinTableRecords.get(key); // join column value
 
-            for (Object value : values)
-            {
-                if (value != null)
-                {
+            for (Object value : values) {
+                if (value != null) {
                     String insertQuery = insert_Query;
                     columnValueBuilder.append(CQLTranslator.QUOTE_STR);
-                    columnValueBuilder.append(PropertyAccessorHelper.getString(key) + "\001"
-                            + PropertyAccessorHelper.getString(value));
+                    columnValueBuilder.append(
+                        PropertyAccessorHelper.getString(key) + "\001" + PropertyAccessorHelper.getString(value));
                     columnValueBuilder.append(CQLTranslator.QUOTE_STR);
                     columnValueBuilder.append(CQLTranslator.COMMA_STR);
                     translator.appendValue(columnValueBuilder, key.getClass(), key, true, false);
                     columnValueBuilder.append(CQLTranslator.COMMA_STR);
                     translator.appendValue(columnValueBuilder, value.getClass(), value, true, false);
 
-                    insertQuery = StringUtils.replace(insertQuery, CQLTranslator.COLUMN_VALUES,
-                            columnValueBuilder.toString());
+                    insertQuery =
+                        StringUtils.replace(insertQuery, CQLTranslator.COLUMN_VALUES, columnValueBuilder.toString());
                     statements.append(insertQuery);
                     statements.append(" ");
                 }
             }
         }
 
-        if (!StringUtils.isBlank(statements.toString()))
-        {
+        if (!StringUtils.isBlank(statements.toString())) {
             batch_Query = StringUtils.replace(batch_Query, CQLTranslator.STATEMENT, statements.toString());
             StringBuilder batchBuilder = new StringBuilder();
             batchBuilder.append(batch_Query);
@@ -333,42 +306,39 @@ public class DSClient extends CassandraClientBase implements Client<DSCassQuery>
     /*
      * (non-Javadoc)
      * 
-     * @see com.impetus.kundera.client.Client#getColumnsById(java.lang.String,
-     * java.lang.String, java.lang.String, java.lang.String, java.lang.Object,
-     * java.lang.Class)
+     * @see com.impetus.kundera.client.Client#getColumnsById(java.lang.String, java.lang.String, java.lang.String,
+     * java.lang.String, java.lang.Object, java.lang.Class)
      */
     @Override
     public <E> List<E> getColumnsById(String schemaName, String tableName, String pKeyColumnName, String columnName,
-            Object pKeyColumnValue, Class columnJavaType)
-    {
+        Object pKeyColumnValue, Class columnJavaType) {
         // select columnName from tableName where pKeyColumnName =
         // pKeyColumnValue
         List results = new ArrayList();
         CQLTranslator translator = new CQLTranslator();
         String selectQuery = translator.SELECT_QUERY;
         selectQuery = StringUtils.replace(selectQuery, CQLTranslator.COLUMN_FAMILY,
-                translator.ensureCase(new StringBuilder(), tableName, false).toString());
+            translator.ensureCase(new StringBuilder(), tableName, false).toString());
         selectQuery = StringUtils.replace(selectQuery, CQLTranslator.COLUMNS,
-                translator.ensureCase(new StringBuilder(), columnName, false).toString());
+            translator.ensureCase(new StringBuilder(), columnName, false).toString());
 
         StringBuilder selectQueryBuilder = new StringBuilder(selectQuery);
 
         selectQueryBuilder.append(CQLTranslator.ADD_WHERE_CLAUSE);
 
         translator.buildWhereClause(selectQueryBuilder, columnJavaType, pKeyColumnName, pKeyColumnValue,
-                CQLTranslator.EQ_CLAUSE, false);
-        selectQueryBuilder
-                .delete(selectQueryBuilder.lastIndexOf(CQLTranslator.AND_CLAUSE), selectQueryBuilder.length());
+            CQLTranslator.EQ_CLAUSE, false);
+        selectQueryBuilder.delete(selectQueryBuilder.lastIndexOf(CQLTranslator.AND_CLAUSE),
+            selectQueryBuilder.length());
 
         ResultSet rSet = execute(selectQueryBuilder.toString(), null);
 
         Iterator<Row> rowIter = rSet.iterator();
-        while (rowIter.hasNext())
-        {
+        while (rowIter.hasNext()) {
             Row row = rowIter.next();
             DataType dataType = row.getColumnDefinitions().getType(columnName);
-            Object columnValue = DSClientUtilities.assign(row, null, null, dataType.getName(), null, columnName, null,
-                    null);
+            Object columnValue =
+                DSClientUtilities.assign(row, null, null, dataType.getName(), null, columnName, null, null);
             results.add(columnValue);
         }
         return results;
@@ -377,54 +347,46 @@ public class DSClient extends CassandraClientBase implements Client<DSCassQuery>
     /*
      * (non-Javadoc)
      * 
-     * @see com.impetus.kundera.client.Client#findIdsByColumn(java.lang.String,
-     * java.lang.String, java.lang.String, java.lang.String, java.lang.Object,
-     * java.lang.Class)
+     * @see com.impetus.kundera.client.Client#findIdsByColumn(java.lang.String, java.lang.String, java.lang.String,
+     * java.lang.String, java.lang.Object, java.lang.Class)
      */
     @Override
     public Object[] findIdsByColumn(String schemaName, String tableName, String pKeyName, String columnName,
-            Object columnValue, Class entityClazz)
-    {
+        Object columnValue, Class entityClazz) {
         EntityMetadata metadata = KunderaMetadataManager.getEntityMetadata(kunderaMetadata, entityClazz);
 
         return getColumnsById(schemaName, tableName, columnName,
-                ((AbstractAttribute) metadata.getIdAttribute()).getJPAColumnName(), columnValue,
-                metadata.getIdAttribute().getBindableJavaType()).toArray();
+            ((AbstractAttribute) metadata.getIdAttribute()).getJPAColumnName(), columnValue,
+            metadata.getIdAttribute().getBindableJavaType()).toArray();
     }
 
     /*
      * (non-Javadoc)
      * 
-     * @see com.impetus.kundera.client.Client#deleteByColumn(java.lang.String,
-     * java.lang.String, java.lang.String, java.lang.Object)
+     * @see com.impetus.kundera.client.Client#deleteByColumn(java.lang.String, java.lang.String, java.lang.String,
+     * java.lang.Object)
      */
     @Override
-    public void deleteByColumn(String schemaName, String tableName, String columnName, Object columnValue)
-    {
+    public void deleteByColumn(String schemaName, String tableName, String columnName, Object columnValue) {
         Session session = factory.getConnection();
         String rowKeyName = null;
         CQLTranslator translator = new CQLTranslator();
-        try
-        {
+        try {
             List<ColumnMetadata> primaryKeys = session.getCluster().getMetadata().getKeyspace("\"" + schemaName + "\"")
-                    .getTable("\"" + tableName + "\"").getPrimaryKey();
+                .getTable("\"" + tableName + "\"").getPrimaryKey();
             rowKeyName = primaryKeys.get(0).getName();
-        }
-        finally
-        {
+        } finally {
             // factory.releaseConnection(session);
         }
 
-        List rowKeys = getColumnsById(schemaName, tableName, columnName, rowKeyName, columnValue,
-                columnValue.getClass());
-        for (Object rowKey : rowKeys)
-        {
-            if (rowKey != null)
-            {
+        List rowKeys =
+            getColumnsById(schemaName, tableName, columnName, rowKeyName, columnValue, columnValue.getClass());
+        for (Object rowKey : rowKeys) {
+            if (rowKey != null) {
                 String deleteQuery = CQLTranslator.DELETE_QUERY;
 
                 deleteQuery = StringUtils.replace(deleteQuery, CQLTranslator.COLUMN_FAMILY,
-                        translator.ensureCase(new StringBuilder(), tableName, false).toString());
+                    translator.ensureCase(new StringBuilder(), tableName, false).toString());
                 StringBuilder deleteQueryBuilder = new StringBuilder(deleteQuery);
                 deleteQueryBuilder.append(CQLTranslator.ADD_WHERE_CLAUSE);
                 deleteQueryBuilder = translator.ensureCase(deleteQueryBuilder, rowKeyName, false);
@@ -438,25 +400,23 @@ public class DSClient extends CassandraClientBase implements Client<DSCassQuery>
     /*
      * (non-Javadoc)
      * 
-     * @see com.impetus.kundera.client.Client#findByRelation(java.lang.String,
-     * java.lang.Object, java.lang.Class)
+     * @see com.impetus.kundera.client.Client#findByRelation(java.lang.String, java.lang.Object, java.lang.Class)
      */
     @Override
-    public List<Object> findByRelation(String colName, Object colValue, Class entityClazz)
-    {
+    public List<Object> findByRelation(String colName, Object colValue, Class entityClazz) {
         EntityMetadata m = KunderaMetadataManager.getEntityMetadata(kunderaMetadata, entityClazz);
         CQLTranslator translator = new CQLTranslator();
         String selectQuery = translator.SELECTALL_QUERY;
         selectQuery = StringUtils.replace(selectQuery, CQLTranslator.COLUMN_FAMILY,
-                translator.ensureCase(new StringBuilder(), m.getTableName(), false).toString());
+            translator.ensureCase(new StringBuilder(), m.getTableName(), false).toString());
 
         StringBuilder selectQueryBuilder = new StringBuilder(selectQuery);
         selectQueryBuilder.append(CQLTranslator.ADD_WHERE_CLAUSE);
 
-        translator.buildWhereClause(selectQueryBuilder, colValue.getClass(), colName, colValue,
-                CQLTranslator.EQ_CLAUSE, false);
-        selectQueryBuilder
-                .delete(selectQueryBuilder.lastIndexOf(CQLTranslator.AND_CLAUSE), selectQueryBuilder.length());
+        translator.buildWhereClause(selectQueryBuilder, colValue.getClass(), colName, colValue, CQLTranslator.EQ_CLAUSE,
+            false);
+        selectQueryBuilder.delete(selectQueryBuilder.lastIndexOf(CQLTranslator.AND_CLAUSE),
+            selectQueryBuilder.length());
 
         ResultSet rSet = (ResultSet) this.execute(selectQueryBuilder.toString(), null);
 
@@ -469,8 +429,7 @@ public class DSClient extends CassandraClientBase implements Client<DSCassQuery>
      * @see com.impetus.kundera.client.Client#getReader()
      */
     @Override
-    public EntityReader getReader()
-    {
+    public EntityReader getReader() {
         return this.reader;
     }
 
@@ -480,153 +439,115 @@ public class DSClient extends CassandraClientBase implements Client<DSCassQuery>
      * @see com.impetus.kundera.client.Client#getQueryImplementor()
      */
     @Override
-    public Class<DSCassQuery> getQueryImplementor()
-    {
+    public Class<DSCassQuery> getQueryImplementor() {
         return DSCassQuery.class;
     }
 
     /*
      * (non-Javadoc)
      * 
-     * @see
-     * com.impetus.client.cassandra.CassandraClientBase#find(java.lang.Class,
-     * java.util.List, boolean,
+     * @see com.impetus.client.cassandra.CassandraClientBase#find(java.lang.Class, java.util.List, boolean,
      * com.impetus.kundera.metadata.model.EntityMetadata, java.lang.Object[])
      */
     @Override
     public List find(Class entityClass, List<String> relationNames, boolean isWrapReq, EntityMetadata metadata,
-            Object... rowIds)
-    {
+        Object... rowIds) {
         return findAll(entityClass, null, rowIds);
     }
 
     /*
      * (non-Javadoc)
      * 
-     * @see
-     * com.impetus.client.cassandra.CassandraClientBase#loadSuperColumns(java
-     * .lang.String, java.lang.String, java.lang.String, java.lang.String[])
+     * @see com.impetus.client.cassandra.CassandraClientBase#loadSuperColumns(java .lang.String, java.lang.String,
+     * java.lang.String, java.lang.String[])
      */
     @Override
     protected List<SuperColumn> loadSuperColumns(String keyspace, String columnFamily, String rowId,
-            String... superColumnNames)
-    {
+        String... superColumnNames) {
         throw new UnsupportedOperationException(
-                "Support for super columns is not available with DS java driver. Either use Thrift or pelops for the same");
+            "Support for super columns is not available with DS java driver. Either use Thrift or pelops for the same");
     }
 
     /*
      * (non-Javadoc)
      * 
-     * @see
-     * com.impetus.client.cassandra.CassandraClientBase#executeQuery(java.lang
-     * .Class, java.util.List, boolean, java.lang.String)
+     * @see com.impetus.client.cassandra.CassandraClientBase#executeQuery(java.lang .Class, java.util.List, boolean,
+     * java.lang.String)
      */
     @Override
-    public List executeQuery(Class clazz, List<String> relationalField, boolean isNative, String cqlQuery)
-    {
+    public List executeQuery(Class clazz, List<String> relationalField, boolean isNative, String cqlQuery) {
         ResultSet rSet = (ResultSet) this.execute(cqlQuery, null);
-        if (clazz == null)
-        {
+        if (clazz == null) {
             return iterateAndReturn(rSet);
         }
         EntityMetadata metadata = KunderaMetadataManager.getEntityMetadata(kunderaMetadata, clazz);
         return iterateAndReturn(rSet, metadata);
     }
-
 
     // XXX
     @Override
-    public List executeQuery(
-	final Class clazz,
-	final List<String> relationalField,
-	final boolean isNative,
-	final String cqlQuery,
-	final List<KunderaQuery.BindParameter> parameters
-    )
-    {
+    public List executeQuery(final Class clazz, final List<String> relationalField, final boolean isNative,
+        final String cqlQuery, final List<KunderaQuery.BindParameter> parameters) {
         ResultSet rSet = (ResultSet) this.execute(cqlQuery, null, parameters);
 
-        if (clazz == null)
-        {
-		if (isNative)
-			return iterateAndReturnNative(rSet);
+        if (clazz == null) {
+            if (isNative)
+                return iterateAndReturnNative(rSet);
             return iterateAndReturn(rSet);
         }
         EntityMetadata metadata = KunderaMetadataManager.getEntityMetadata(kunderaMetadata, clazz);
         return iterateAndReturn(rSet, metadata);
     }
- 
 
+    public ResultSet executeStatement(Statement st) {
 
-    
-    public ResultSet executeStatement(Statement st){
-        
         Session session = factory.getConnection();
         return session.execute(st);
     }
 
-
     /**
      * XXX
      *
-     * Iterate and return for native queries.
-     * Returns a List&lt;Object&gt; or a List&lt;Object[]&gt;
+     * Iterate and return for native queries. Returns a List&lt;Object&gt; or a List&lt;Object[]&gt;
      * 
      * @param rSet
      *            the r set
      * @return the list
      */
-    private List iterateAndReturnNative(final ResultSet rSet)
-    {
+    private List iterateAndReturnNative(final ResultSet rSet) {
         final Iterator<Row> rowIter = rSet.iterator();
         final List results = new ArrayList();
-	final List item = new ArrayList<>();
+        final List item = new ArrayList<>();
 
-	final boolean isSingle = (rSet.getColumnDefinitions().size() == 1);
+        final boolean isSingle = (rSet.getColumnDefinitions().size() == 1);
 
-        while (rowIter.hasNext())
-        {
+        while (rowIter.hasNext()) {
             final Row row = rowIter.next();
 
             final ColumnDefinitions columnDefs = row.getColumnDefinitions();
 
             final Iterator<Definition> columnDefIter = columnDefs.iterator();
 
-	    item.clear();
+            item.clear();
 
-            while (columnDefIter.hasNext())
-            {
+            while (columnDefIter.hasNext()) {
                 final Definition columnDef = columnDefIter.next();
 
-		item.add(
-			DSClientUtilities.assign(
-				row,
-				null,
-				null,
-				columnDef.getType().getName(),
-				null,
-                                columnDef.getName(),
-				null,
-				null
-			)
-		);
+                item.add(DSClientUtilities.assign(row, null, null, columnDef.getType().getName(), null,
+                    columnDef.getName(), null, null));
             }
 
-	    if (isSingle) {
-		if (!item.isEmpty())
-			results.add(item.get(0));
-		else
-			results.add(null);
-	    } else
-	   	 results.add(item.toArray(new Object[item.size()]));
+            if (isSingle) {
+                if (!item.isEmpty())
+                    results.add(item.get(0));
+                else
+                    results.add(null);
+            } else
+                results.add(item.toArray(new Object[item.size()]));
         }
 
         return results;
     }
-
- 
-
 
     /**
      * Iterate and return.
@@ -635,24 +556,19 @@ public class DSClient extends CassandraClientBase implements Client<DSCassQuery>
      *            the r set
      * @return the list
      */
-    private List iterateAndReturn(ResultSet rSet)
-    {
+    private List iterateAndReturn(ResultSet rSet) {
         Iterator<Row> rowIter = rSet.iterator();
         List results = new ArrayList();
 
-        while (rowIter.hasNext())
-        {
+        while (rowIter.hasNext()) {
             Row row = rowIter.next();
             ColumnDefinitions columnDefs = row.getColumnDefinitions();
             Iterator<Definition> columnDefIter = columnDefs.iterator();
             Map rowData = new HashMap();
-            while (columnDefIter.hasNext())
-            {
+            while (columnDefIter.hasNext()) {
                 Definition columnDef = columnDefIter.next();
-                rowData.put(
-                        columnDef.getName(),
-                        DSClientUtilities.assign(row, null, null, columnDef.getType().getName(), null,
-                                columnDef.getName(), null, null));
+                rowData.put(columnDef.getName(), DSClientUtilities.assign(row, null, null,
+                    columnDef.getType().getName(), null, columnDef.getName(), null, null));
             }
             results.add(rowData);
         }
@@ -662,59 +578,48 @@ public class DSClient extends CassandraClientBase implements Client<DSCassQuery>
     /*
      * (non-Javadoc)
      * 
-     * @see
-     * com.impetus.client.cassandra.CassandraClientBase#find(java.util.List,
-     * com.impetus.kundera.metadata.model.EntityMetadata, boolean,
-     * java.util.List, int, java.util.List)
+     * @see com.impetus.client.cassandra.CassandraClientBase#find(java.util.List,
+     * com.impetus.kundera.metadata.model.EntityMetadata, boolean, java.util.List, int, java.util.List)
      */
     @Override
     public List find(List<IndexClause> ixClause, EntityMetadata m, boolean isRelation, List<String> relations,
-            int maxResult, List<String> columns)
-    {
+        int maxResult, List<String> columns) {
         throw new UnsupportedOperationException("Support available only for thrift/pelops.");
     }
 
     /*
      * (non-Javadoc)
      * 
-     * @see com.impetus.client.cassandra.CassandraClientBase#findByRange(byte[],
-     * byte[], com.impetus.kundera.metadata.model.EntityMetadata, boolean,
-     * java.util.List, java.util.List, java.util.List, int)
+     * @see com.impetus.client.cassandra.CassandraClientBase#findByRange(byte[], byte[],
+     * com.impetus.kundera.metadata.model.EntityMetadata, boolean, java.util.List, java.util.List, java.util.List, int)
      */
     @Override
     public List findByRange(byte[] muinVal, byte[] maxVal, EntityMetadata m, boolean isWrapReq, List<String> relations,
-            List<String> columns, List<IndexExpression> conditions, int maxResults) throws Exception
-    {
+        List<String> columns, List<IndexExpression> conditions, int maxResults) throws Exception {
         throw new UnsupportedOperationException("Support available only for thrift/pelops.");
     }
 
     /*
      * (non-Javadoc)
      * 
-     * @see
-     * com.impetus.client.cassandra.CassandraClientBase#searchInInvertedIndex
-     * (java.lang.String, com.impetus.kundera.metadata.model.EntityMetadata,
-     * java.util.Map)
+     * @see com.impetus.client.cassandra.CassandraClientBase#searchInInvertedIndex (java.lang.String,
+     * com.impetus.kundera.metadata.model.EntityMetadata, java.util.Map)
      */
     @Override
     public List<SearchResult> searchInInvertedIndex(String columnFamilyName, EntityMetadata m,
-            Map<Boolean, List<IndexClause>> indexClauseMap)
-    {
+        Map<Boolean, List<IndexClause>> indexClauseMap) {
         throw new UnsupportedOperationException("Support available only for thrift/pelops.");
     }
 
     /*
      * (non-Javadoc)
      * 
-     * @see
-     * com.impetus.client.cassandra.CassandraClientBase#find(com.impetus.kundera
-     * .metadata.model.EntityMetadata, java.util.List, java.util.List, int,
-     * java.util.List)
+     * @see com.impetus.client.cassandra.CassandraClientBase#find(com.impetus.kundera .metadata.model.EntityMetadata,
+     * java.util.List, java.util.List, int, java.util.List)
      */
     @Override
     public List<EnhanceEntity> find(EntityMetadata m, List<String> relationNames, List<IndexClause> conditions,
-            int maxResult, List<String> columns)
-    {
+        int maxResult, List<String> columns) {
         throw new UnsupportedOperationException("Support available only for thrift/pelops.");
     }
 
@@ -724,35 +629,30 @@ public class DSClient extends CassandraClientBase implements Client<DSCassQuery>
      * @see com.impetus.client.cassandra.CassandraClientBase#getDataHandler()
      */
     @Override
-    protected CassandraDataHandler getDataHandler()
-    {
+    protected CassandraDataHandler getDataHandler() {
         throw new UnsupportedOperationException("Support available only for thrift/pelops.");
     }
 
     /*
      * (non-Javadoc)
      * 
-     * @see
-     * com.impetus.client.cassandra.CassandraClientBase#delete(java.lang.Object,
-     * java.lang.Object)
+     * @see com.impetus.client.cassandra.CassandraClientBase#delete(java.lang.Object, java.lang.Object)
      */
     @Override
-    public void delete(Object entity, Object pKey)
-    {
+    public void delete(Object entity, Object pKey) {
         EntityMetadata m = KunderaMetadataManager.getEntityMetadata(kunderaMetadata, entity.getClass());
 
-        MetamodelImpl metaModel = (MetamodelImpl) kunderaMetadata.getApplicationMetadata().getMetamodel(
-                m.getPersistenceUnit());
+        MetamodelImpl metaModel =
+            (MetamodelImpl) kunderaMetadata.getApplicationMetadata().getMetamodel(m.getPersistenceUnit());
 
         AbstractManagedType managedType = (AbstractManagedType) metaModel.entity(m.getEntityClazz());
 
         // For secondary tables.
-        List<String> secondaryTables = ((DefaultEntityAnnotationProcessor) managedType.getEntityAnnotation())
-                .getSecondaryTablesName();
+        List<String> secondaryTables =
+            ((DefaultEntityAnnotationProcessor) managedType.getEntityAnnotation()).getSecondaryTablesName();
         secondaryTables.add(m.getTableName());
 
-        for (String tableName : secondaryTables)
-        {
+        for (String tableName : secondaryTables) {
             this.execute(onDeleteQuery(m, tableName, metaModel, pKey), null);
         }
     }
@@ -763,8 +663,7 @@ public class DSClient extends CassandraClientBase implements Client<DSCassQuery>
      * @see com.impetus.client.cassandra.CassandraClientBase#getConnection()
      */
     @Override
-    protected Object getConnection()
-    {
+    protected Object getConnection() {
         // do nothing returning null.
         return null;
     }
@@ -772,192 +671,122 @@ public class DSClient extends CassandraClientBase implements Client<DSCassQuery>
     /*
      * (non-Javadoc)
      * 
-     * @see
-     * com.impetus.client.cassandra.CassandraClientBase#getConnection(java.lang
-     * .Object)
+     * @see com.impetus.client.cassandra.CassandraClientBase#getConnection(java.lang .Object)
      */
     @Override
-    protected Object getConnection(Object connection)
-    {
+    protected Object getConnection(Object connection) {
         return null;
     }
 
     /*
      * (non-Javadoc)
      * 
-     * @see
-     * com.impetus.client.cassandra.CassandraClientBase#releaseConnection(java
-     * .lang.Object)
+     * @see com.impetus.client.cassandra.CassandraClientBase#releaseConnection(java .lang.Object)
      */
     @Override
-    protected void releaseConnection(Object conn)
-    {
+    protected void releaseConnection(Object conn) {
         // do nothing
     }
 
     /*
      * (non-Javadoc)
      * 
-     * @see
-     * com.impetus.client.cassandra.CassandraClientBase#execute(java.lang.String
-     * , java.lang.Object)
+     * @see com.impetus.client.cassandra.CassandraClientBase#execute(java.lang.String , java.lang.Object)
      */
     @Override
-    public <T> T execute(final String query, Object connection)
-    {
+    public <T> T execute(final String query, Object connection) {
 
         Session session = factory.getConnection();
-        try
-        {
+        try {
             Statement queryStmt = new SimpleStatement(query);
             KunderaCoreUtils.printQuery(query, showQuery);
             queryStmt.setConsistencyLevel(ConsistencyLevel.valueOf(this.consistencyLevel.name()));
             return (T) session.execute(queryStmt);
-        }
-        catch (Exception e)
-        {
+        } catch (Exception e) {
             log.error("Error while executing query {}.", query);
             throw new KunderaException(e);
-        }
-        finally
-        {
+        } finally {
             // factory.releaseConnection(session);
         }
     }
 
-
     @Override
-    public <T> T execute(final String query, Object connection, final List<KunderaQuery.BindParameter> parameters)
-    {
+    public <T> T execute(final String query, Object connection, final List<KunderaQuery.BindParameter> parameters) {
 
         Session session = factory.getConnection();
 
-        try
-        {
-		final PreparedStatement preparedStatement = session.prepare(query);
-		final BoundStatement boundStatement = preparedStatement.bind();
+        try {
+            final PreparedStatement preparedStatement = session.prepare(query);
+            final BoundStatement boundStatement = preparedStatement.bind();
 
-		for (KunderaQuery.BindParameter value: parameters) {
+            for (KunderaQuery.BindParameter value : parameters) {
 
-			log.info(
-				"binding [" + value.getIndex() + ":" + value.getName() +
-				"] to [" + value.getValue() + "]"
-			);
+                log.info("binding [" + value.getIndex() + ":" + value.getName() + "] to [" + value.getValue() + "]");
 
-			if (value.getValue() != null) {
+                if (value.getValue() != null) {
 
-				if (value.getValue() instanceof String) {
-					if (value.isNamed())
-						boundStatement.setString(
-							value.getName(),
-							(String) value.getValue()
-						);
-					else
-						boundStatement.setString(
-							value.getIndex() - 1,
-							(String) value.getValue()
-						);
-				} else if (value.getValue() instanceof Integer) {
-					if (value.isNamed())
-						boundStatement.setInt(
-							value.getName(),
-							(Integer) value.getValue()
-						);
-					else
-						boundStatement.setInt(
-							value.getIndex() - 1,
-							(Integer) value.getValue()
-						);
-				} else if (value.getValue() instanceof Long) {
-					if (value.isNamed())
-						boundStatement.setLong(
-							value.getName(),
-							(Long) value.getValue()
-						);
-					else
-						boundStatement.setLong(
-							value.getIndex() - 1,
-							(Long) value.getValue()
-						);
-				} else if (value.getValue() instanceof java.util.UUID) {
-					if (value.isNamed())
-						boundStatement.setUUID(
-							value.getName(),
-							(java.util.UUID) value.getValue()
-						);
-					else
-						boundStatement.setUUID(
-							value.getIndex() - 1,
-							(java.util.UUID) value.getValue()
-						);
-				} else if (value.getValue() instanceof List) {
-					if (value.isNamed())
-						boundStatement.setList(
-							value.getName(),
-							(List) value.getValue()
-						);
-					else
-						boundStatement.setList(
-							value.getIndex() - 1,
-							(List) value.getValue()
-						);
-				} else {
-					throw new IllegalArgumentException(
-						"bind parameter type [" +
-						value.getValue().getClass() +
-						"] is not supported, " + value.getIndex() + ":" + value.getName()
-					);
-				}
-			} else {
-				throw new IllegalArgumentException(
-					"setting null bind parameters is not supported"
-				);
-			}
-		}
+                    if (value.getValue() instanceof String) {
+                        if (value.isNamed())
+                            boundStatement.setString(value.getName(), (String) value.getValue());
+                        else
+                            boundStatement.setString(value.getIndex() - 1, (String) value.getValue());
+                    } else if (value.getValue() instanceof Integer) {
+                        if (value.isNamed())
+                            boundStatement.setInt(value.getName(), (Integer) value.getValue());
+                        else
+                            boundStatement.setInt(value.getIndex() - 1, (Integer) value.getValue());
+                    } else if (value.getValue() instanceof Long) {
+                        if (value.isNamed())
+                            boundStatement.setLong(value.getName(), (Long) value.getValue());
+                        else
+                            boundStatement.setLong(value.getIndex() - 1, (Long) value.getValue());
+                    } else if (value.getValue() instanceof java.util.UUID) {
+                        if (value.isNamed())
+                            boundStatement.setUUID(value.getName(), (java.util.UUID) value.getValue());
+                        else
+                            boundStatement.setUUID(value.getIndex() - 1, (java.util.UUID) value.getValue());
+                    } else if (value.getValue() instanceof List) {
+                        if (value.isNamed())
+                            boundStatement.setList(value.getName(), (List) value.getValue());
+                        else
+                            boundStatement.setList(value.getIndex() - 1, (List) value.getValue());
+                    } else {
+                        throw new IllegalArgumentException("bind parameter type [" + value.getValue().getClass()
+                            + "] is not supported, " + value.getIndex() + ":" + value.getName());
+                    }
+                } else {
+                    throw new IllegalArgumentException("setting null bind parameters is not supported");
+                }
+            }
 
-		KunderaCoreUtils.printQuery(query, showQuery);
+            KunderaCoreUtils.printQuery(query, showQuery);
 
-		boundStatement.setConsistencyLevel(
-			ConsistencyLevel.valueOf(this.consistencyLevel.name())
-		);
+            boundStatement.setConsistencyLevel(ConsistencyLevel.valueOf(this.consistencyLevel.name()));
 
-		return (T) session.execute(boundStatement);
-        }
-        catch (Exception e)
-        {
+            return (T) session.execute(boundStatement);
+        } catch (Exception e) {
             log.error("Error while executing query {}.", query);
             throw new KunderaException(e);
-        }
-        finally
-        {
+        } finally {
             // factory.releaseConnection(session);
         }
     }
-
-
 
     /*
      * (non-Javadoc)
      * 
-     * @see
-     * com.impetus.client.cassandra.CassandraClientBase#executeUpdateDeleteQuery
-     * (java.lang.String)
+     * @see com.impetus.client.cassandra.CassandraClientBase#executeUpdateDeleteQuery (java.lang.String)
      */
-    public int executeUpdateDeleteQuery(String cqlQuery)
-    {
+    public int executeUpdateDeleteQuery(String cqlQuery) {
         Session session = null;
-        try
-        {
-            if (log.isInfoEnabled())
-            {
+        try {
+            if (log.isInfoEnabled()) {
                 log.info("Executing cql query {}.", cqlQuery);
             }
             session = factory.getConnection();
             KunderaCoreUtils.printQuery(cqlQuery, showQuery);
             session.execute(cqlQuery);
-        }
-        finally
-        {
+        } finally {
             // factory.releaseConnection(session);
         }
         // TODO: can't find a way to return number of updated records.
@@ -976,10 +805,9 @@ public class DSClient extends CassandraClientBase implements Client<DSCassQuery>
      *            the metadata
      * @return the list
      */
-    private List iterateAndReturn(ResultSet rSet, EntityMetadata metadata)
-    {
-        MetamodelImpl metaModel = (MetamodelImpl) kunderaMetadata.getApplicationMetadata().getMetamodel(
-                metadata.getPersistenceUnit());
+    private List iterateAndReturn(ResultSet rSet, EntityMetadata metadata) {
+        MetamodelImpl metaModel =
+            (MetamodelImpl) kunderaMetadata.getApplicationMetadata().getMetamodel(metadata.getPersistenceUnit());
         EntityType entityType = metaModel.entity(metadata.getEntityClazz());
 
         Iterator<Row> rowIter = rSet.iterator();
@@ -987,8 +815,7 @@ public class DSClient extends CassandraClientBase implements Client<DSCassQuery>
 
         Map<String, Object> relationalValues = new HashMap<String, Object>();
 
-        while (rowIter.hasNext())
-        {
+        while (rowIter.hasNext()) {
             Object entity = null;
             Row row = rowIter.next();
             populateObjectFromRow(metadata, metaModel, entityType, results, relationalValues, entity, row);
@@ -996,32 +823,25 @@ public class DSClient extends CassandraClientBase implements Client<DSCassQuery>
         return results;
     }
 
-    void populateObjectFromRow(EntityMetadata metadata, MetamodelImpl metaModel, EntityType entityType,
-            List results, Map<String, Object> relationalValues, Object entity, Row row)
-    {
+    void populateObjectFromRow(EntityMetadata metadata, MetamodelImpl metaModel, EntityType entityType, List results,
+        Map<String, Object> relationalValues, Object entity, Row row) {
         ColumnDefinitions columnDefs = row.getColumnDefinitions();
         Iterator<Definition> columnDefIter = columnDefs.iterator();
 
         entity = iteratorColumns(metadata, metaModel, entityType, relationalValues, entity, row, columnDefIter);
 
-        if (entity != null && entity.getClass().isAssignableFrom(metadata.getEntityClazz()))
-        {
+        if (entity != null && entity.getClass().isAssignableFrom(metadata.getEntityClazz())) {
             Object rowKey = PropertyAccessorHelper.getId(entity, metadata);
 
             // populate secondary tables data if there is any.
             populateSecondaryTableData(rowKey, entity, metaModel, metadata);
 
-            if (!relationalValues.isEmpty())
-            {
+            if (!relationalValues.isEmpty()) {
                 results.add(new EnhanceEntity(entity, rowKey, relationalValues));
-            }
-            else
-            {
+            } else {
                 results.add(entity);
             }
-        }
-        else if (entity != null)
-        {
+        } else if (entity != null) {
             results.add(entity);
         }
     }
@@ -1039,14 +859,12 @@ public class DSClient extends CassandraClientBase implements Client<DSCassQuery>
      *            the metadata
      */
     private void populateSecondaryTableData(Object rowId, Object entity, MetamodelImpl metaModel,
-            EntityMetadata metadata)
-    {
+        EntityMetadata metadata) {
         AbstractManagedType managedType = (AbstractManagedType) metaModel.entity(metadata.getEntityClazz());
-        List<String> secondaryTables = ((DefaultEntityAnnotationProcessor) managedType.getEntityAnnotation())
-                .getSecondaryTablesName();
+        List<String> secondaryTables =
+            ((DefaultEntityAnnotationProcessor) managedType.getEntityAnnotation()).getSecondaryTablesName();
 
-        for (String tableName : secondaryTables)
-        {
+        for (String tableName : secondaryTables) {
             StringBuilder builder = createSelectQuery(rowId, metadata, tableName);
             ResultSet rSet = this.execute(builder.toString(), null);
 
@@ -1057,7 +875,7 @@ public class DSClient extends CassandraClientBase implements Client<DSCassQuery>
             Iterator<Definition> columnDefIter = columnDefs.iterator();
 
             entity = iteratorColumns(metadata, metaModel, metaModel.entity(metadata.getEntityClazz()),
-                    new HashMap<String, Object>(), entity, row, columnDefIter);
+                new HashMap<String, Object>(), entity, row, columnDefIter);
         }
     }
 
@@ -1081,46 +899,34 @@ public class DSClient extends CassandraClientBase implements Client<DSCassQuery>
      * @return the object
      */
     private Object iteratorColumns(EntityMetadata metadata, MetamodelImpl metamodel, EntityType entityType,
-            Map<String, Object> relationalValues, Object entity, Row row, Iterator<Definition> columnDefIter)
-    {
-        while (columnDefIter.hasNext())
-        {
+        Map<String, Object> relationalValues, Object entity, Row row, Iterator<Definition> columnDefIter) {
+        while (columnDefIter.hasNext()) {
             Definition columnDef = columnDefIter.next();
             final String columnName = columnDef.getName(); // column name
 
             DataType dataType = columnDef.getType(); // data type
 
             if (metadata.getRelationNames() != null && metadata.getRelationNames().contains(columnName)
-                    && !columnName.equals(((AbstractAttribute) metadata.getIdAttribute()).getJPAColumnName()))
-            {
+                && !columnName.equals(((AbstractAttribute) metadata.getIdAttribute()).getJPAColumnName())) {
                 Object relationalValue = DSClientUtilities.assign(row, null, metadata, dataType.getName(), entityType,
-                        columnName, null, metamodel);
+                    columnName, null, metamodel);
                 relationalValues.put(columnName, relationalValue);
-            }
-            else
-            {
-                String fieldName = columnName
-                        .equals(((AbstractAttribute) metadata.getIdAttribute()).getJPAColumnName()) ? metadata
-                        .getIdAttribute().getName() : metadata.getFieldName(columnName);
+            } else {
+                String fieldName = columnName.equals(((AbstractAttribute) metadata.getIdAttribute()).getJPAColumnName())
+                    ? metadata.getIdAttribute().getName() : metadata.getFieldName(columnName);
                 Attribute attribute = fieldName != null ? entityType.getAttribute(fieldName) : null;
 
-                if (attribute != null)
-                {
-                    if (!attribute.isAssociation())
-                    {
+                if (attribute != null) {
+                    if (!attribute.isAssociation()) {
                         entity = DSClientUtilities.assign(row, entity, metadata, dataType.getName(), entityType,
-                                columnName, null, metamodel);
-                    }
-                }
-                else if (metamodel.isEmbeddable(metadata.getIdAttribute().getBindableJavaType()))
-                {
-                    entity = populateCompositeId(metadata, entity, columnName, row, metamodel,
-                            metadata.getIdAttribute(), metadata.getEntityClazz(), dataType);
-                }
-                else
-                {
-                    entity = DSClientUtilities.assign(row, entity, metadata, dataType.getName(), entityType,
                             columnName, null, metamodel);
+                    }
+                } else if (metamodel.isEmbeddable(metadata.getIdAttribute().getBindableJavaType())) {
+                    entity = populateCompositeId(metadata, entity, columnName, row, metamodel,
+                        metadata.getIdAttribute(), metadata.getEntityClazz(), dataType);
+                } else {
+                    entity = DSClientUtilities.assign(row, entity, metadata, dataType.getName(), entityType, columnName,
+                        null, metamodel);
                 }
             }
         }
@@ -1133,8 +939,7 @@ public class DSClient extends CassandraClientBase implements Client<DSCassQuery>
      * @see com.impetus.client.cassandra.CassandraClientBase#close()
      */
     @Override
-    public void close()
-    {
+    public void close() {
         super.close();
     }
 
@@ -1144,8 +949,7 @@ public class DSClient extends CassandraClientBase implements Client<DSCassQuery>
      * @see com.impetus.kundera.client.ClientBase#getPersistenceUnit()
      */
     @Override
-    public String getPersistenceUnit()
-    {
+    public String getPersistenceUnit() {
         return super.getPersistenceUnit();
     }
 
@@ -1171,46 +975,35 @@ public class DSClient extends CassandraClientBase implements Client<DSCassQuery>
      * @return the object
      */
     private Object populateCompositeId(EntityMetadata metadata, Object entity, String columnName, Row row,
-            MetamodelImpl metaModel, Attribute attribute, Class<?> entityClazz, DataType dataType)
-    {
+        MetamodelImpl metaModel, Attribute attribute, Class<?> entityClazz, DataType dataType) {
         Class javaType = ((AbstractAttribute) attribute).getBindableJavaType();
 
-        if (metaModel.isEmbeddable(javaType))
-        {
+        if (metaModel.isEmbeddable(javaType)) {
             EmbeddableType compoundKey = metaModel.embeddable(javaType);
             Object compoundKeyObject = null;
-            try
-            {
+            try {
                 Set<Attribute> attributes = compoundKey.getAttributes();
                 entity = KunderaCoreUtils.initialize(entityClazz, entity);
 
-                for (Attribute compoundAttribute : attributes)
-                {
-                    compoundKeyObject = compoundKeyObject == null ? getCompoundKey(attribute, entity)
-                            : compoundKeyObject;
+                for (Attribute compoundAttribute : attributes) {
+                    compoundKeyObject =
+                        compoundKeyObject == null ? getCompoundKey(attribute, entity) : compoundKeyObject;
 
-                    if (metaModel.isEmbeddable(((AbstractAttribute) compoundAttribute).getBindableJavaType()))
-                    {
+                    if (metaModel.isEmbeddable(((AbstractAttribute) compoundAttribute).getBindableJavaType())) {
                         Object compoundObject = populateCompositeId(metadata, compoundKeyObject, columnName, row,
-                                metaModel, compoundAttribute, javaType, dataType);
+                            metaModel, compoundAttribute, javaType, dataType);
                         PropertyAccessorHelper.set(entity, (Field) attribute.getJavaMember(), compoundObject);
-                    }
-                    else if (((AbstractAttribute) compoundAttribute).getJPAColumnName().equals(columnName))
-                    {
+                    } else if (((AbstractAttribute) compoundAttribute).getJPAColumnName().equals(columnName)) {
                         DSClientUtilities.assign(row, compoundKeyObject, null, dataType.getName(), null, columnName,
-                                (Field) compoundAttribute.getJavaMember(), metaModel);
+                            (Field) compoundAttribute.getJavaMember(), metaModel);
                         PropertyAccessorHelper.set(entity, (Field) attribute.getJavaMember(), compoundKeyObject);
                         break;
                     }
                 }
-            }
-            catch (IllegalArgumentException iaex)
-            {
+            } catch (IllegalArgumentException iaex) {
                 // ignore as it might not represented within entity.
                 // No need for any logger message
-            }
-            catch (Exception e)
-            {
+            } catch (Exception e) {
                 log.error("Error while retrieving data, Caused by: .", e);
                 throw new PersistenceException(e);
             }
@@ -1231,15 +1024,12 @@ public class DSClient extends CassandraClientBase implements Client<DSCassQuery>
      * @throws IllegalAccessException
      *             the illegal access exception
      */
-    private Object getCompoundKey(Attribute attribute, Object entity) throws InstantiationException,
-            IllegalAccessException
-    {
+    private Object getCompoundKey(Attribute attribute, Object entity)
+        throws InstantiationException, IllegalAccessException {
         Object compoundKeyObject = null;
-        if (entity != null)
-        {
+        if (entity != null) {
             compoundKeyObject = PropertyAccessorHelper.getObject(entity, (Field) attribute.getJavaMember());
-            if (compoundKeyObject == null)
-            {
+            if (compoundKeyObject == null) {
                 compoundKeyObject = ((AbstractAttribute) attribute).getBindableJavaType().newInstance();
             }
         }
@@ -1253,8 +1043,7 @@ public class DSClient extends CassandraClientBase implements Client<DSCassQuery>
      * @see com.impetus.kundera.client.Client#getIdGenerator()
      */
     @Override
-    public Generator getIdGenerator()
-    {
+    public Generator getIdGenerator() {
         return (Generator) KunderaCoreUtils.createNewInstance(DSIdGenerator.class);
     }
 }

--- a/src/kundera-cassandra/cassandra-ds-driver/src/test/java/com/impetus/kundera/client/cassandra/crud/NativeQueryBindParametersTest.java
+++ b/src/kundera-cassandra/cassandra-ds-driver/src/test/java/com/impetus/kundera/client/cassandra/crud/NativeQueryBindParametersTest.java
@@ -23,8 +23,6 @@ import java.util.Map;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.Persistence;
-import javax.persistence.Query;
-import javax.persistence.TypedQuery;
 
 import junit.framework.Assert;
 
@@ -39,14 +37,12 @@ import com.impetus.client.crud.PersonCassandra.Day;
 import com.impetus.kundera.PersistenceProperties;
 import com.impetus.kundera.client.cassandra.persistence.CassandraCli;
 
-
 /**
  * Test case to perform native queries with bind parameters
  * 
  * @author dev@antonyudin.com
  */
-public class NativeQueryBindParametersTest extends BaseTest
-{
+public class NativeQueryBindParametersTest extends BaseTest {
     private static final String _PU = "cassandra_ds_pu";
 
     /** The emf. */
@@ -57,7 +53,6 @@ public class NativeQueryBindParametersTest extends BaseTest
 
     protected Map propertyMap = null;
 
-
     /**
      * Sets the up.
      * 
@@ -65,14 +60,12 @@ public class NativeQueryBindParametersTest extends BaseTest
      *             the exception
      */
     @Before
-    public void setUp() throws Exception
-    {
-        
+    public void setUp() throws Exception {
+
         CassandraCli.cassandraSetUp();
         System.setProperty("cassandra.start_native_transport", "true");
 
-        if (propertyMap == null)
-        {
+        if (propertyMap == null) {
             propertyMap = new HashMap();
             propertyMap.put(PersistenceProperties.KUNDERA_DDL_AUTO_PREPARE, "create");
         }
@@ -80,27 +73,26 @@ public class NativeQueryBindParametersTest extends BaseTest
         emf = Persistence.createEntityManagerFactory(_PU, propertyMap);
         entityManager = emf.createEntityManager();
 
-	    final List<PersonCassandra> entities = new ArrayList<>();
+        final List<PersonCassandra> entities = new ArrayList<>();
 
-	    for (int i = 0; i < 10; i++) {
+        for (int i = 0; i < 10; i++) {
 
-		final PersonCassandra entity = new PersonCassandra();
-		entity.setPersonId(Integer.toString(i));
-		entity.setPersonName("name" + i);
-		entity.setAge(10 + i);
-		entity.setDay(Day.thursday);
-		entity.setMonth(Month.APRIL);
+            final PersonCassandra entity = new PersonCassandra();
+            entity.setPersonId(Integer.toString(i));
+            entity.setPersonName("name" + i);
+            entity.setAge(10 + i);
+            entity.setDay(Day.thursday);
+            entity.setMonth(Month.APRIL);
 
-		entities.add(entity);
-	    }
+            entities.add(entity);
+        }
 
+        for (PersonCassandra entity : entities) {
+            entityManager.persist(entity);
+        }
 
-	    for (PersonCassandra entity: entities) {
-		    entityManager.persist(entity);
-	    }
-
-	    entityManager.flush();
-            entityManager.clear();
+        entityManager.flush();
+        entityManager.clear();
 
     }
 
@@ -111,28 +103,21 @@ public class NativeQueryBindParametersTest extends BaseTest
      *             the exception
      */
     @Test
-    public void onTestNativeQueriesNamedParametersInteger() throws Exception
-    {
+    public void onTestNativeQueriesNamedParametersInteger() throws Exception {
 
-	    final List<Object[]> result = entityManager.createNativeQuery(
-		"SELECT " +
-		     "\"personId\", \"PERSON_NAME\", \"AGE\" " +
-		"FROM " +
-		     "\"PERSON\" " +
-	        "WHERE " +
-		     "\"AGE\" = :age " +
-		"ALLOW FILTERING"
-            ).setParameter("age", 10 + 3).getResultList();
+        final List<Object[]> result = entityManager
+            .createNativeQuery("SELECT " + "\"personId\", \"PERSON_NAME\", \"AGE\" " + "FROM " + "\"PERSON\" "
+                + "WHERE " + "\"AGE\" = :age " + "ALLOW FILTERING")
+            .setParameter("age", 10 + 3).getResultList();
 
-            Assert.assertNotNull(result);
-            Assert.assertEquals(result.size(), 1);
-            Assert.assertEquals(result.get(0)[0], "3");
-            Assert.assertEquals(result.get(0)[1], "name" + 3);
-            Assert.assertEquals(result.get(0)[2], 10 + 3);
+        Assert.assertNotNull(result);
+        Assert.assertEquals(result.size(), 1);
+        Assert.assertEquals(result.get(0)[0], "3");
+        Assert.assertEquals(result.get(0)[1], "name" + 3);
+        Assert.assertEquals(result.get(0)[2], 10 + 3);
 
-            entityManager.clear();
+        entityManager.clear();
     }
-
 
     /**
      * test native queries with named bind parameters
@@ -141,53 +126,41 @@ public class NativeQueryBindParametersTest extends BaseTest
      *             the exception
      */
     @Test
-    public void onTestNativeQueriesNamedParametersString() throws Exception
-    {
+    public void onTestNativeQueriesNamedParametersString() throws Exception {
 
-	    final List<Object[]> result = entityManager.createNativeQuery(
-		"SELECT " +
-		     "\"personId\", \"PERSON_NAME\" " +
-		"FROM " +
-		     "\"PERSON\" " +
-	        "WHERE " +
-		     "\"personId\" = :personId"
-            ).setParameter("personId", "3").getResultList();
+        final List<Object[]> result =
+            entityManager.createNativeQuery("SELECT " + "\"personId\", \"PERSON_NAME\" " + "FROM " + "\"PERSON\" "
+                + "WHERE " + "\"personId\" = :personId").setParameter("personId", "3").getResultList();
 
-            Assert.assertNotNull(result);
-            Assert.assertEquals(result.size(), 1);
-            Assert.assertEquals(result.get(0)[0], "3");
-            Assert.assertEquals(result.get(0)[1], "name" + 3);
+        Assert.assertNotNull(result);
+        Assert.assertEquals(result.size(), 1);
+        Assert.assertEquals(result.get(0)[0], "3");
+        Assert.assertEquals(result.get(0)[1], "name" + 3);
 
-            entityManager.clear();
+        entityManager.clear();
     }
 
-   /**
+    /**
      * test native queries with indexed bind parameters
      * 
      * @throws Exception
      *             the exception
      */
     @Test
-    public void onTestNativeQueriesIndexedParametersString() throws Exception
-    {
+    public void onTestNativeQueriesIndexedParametersString() throws Exception {
 
-	    final List<Object[]> result = entityManager.createNativeQuery(
-		"SELECT " +
-		     "\"personId\", \"PERSON_NAME\" " +
-		"FROM " +
-		     "\"PERSON\" " +
-	        "WHERE " +
-		     "\"personId\" = ?"
-            ).setParameter(1, "2").getResultList();
+        final List<Object[]> result = entityManager
+            .createNativeQuery(
+                "SELECT " + "\"personId\", \"PERSON_NAME\" " + "FROM " + "\"PERSON\" " + "WHERE " + "\"personId\" = ?")
+            .setParameter(1, "2").getResultList();
 
-            Assert.assertNotNull(result);
-            Assert.assertEquals(result.size(), 1);
-            Assert.assertEquals(result.get(0)[0], "2");
-            Assert.assertEquals(result.get(0)[1], "name" + 2);
+        Assert.assertNotNull(result);
+        Assert.assertEquals(result.size(), 1);
+        Assert.assertEquals(result.get(0)[0], "2");
+        Assert.assertEquals(result.get(0)[1], "name" + 2);
 
-            entityManager.clear();
+        entityManager.clear();
     }
-
 
     /**
      * Tear down.
@@ -196,8 +169,7 @@ public class NativeQueryBindParametersTest extends BaseTest
      *             the exception
      */
     @After
-    public void tearDown() throws Exception
-    {
+    public void tearDown() throws Exception {
         entityManager.close();
         emf.close();
         CassandraCli.dropKeySpace("KunderaExamples");

--- a/src/kundera-cassandra/cassandra-ds-driver/src/test/java/com/impetus/kundera/client/cassandra/crud/NativeQueryBindParametersTest.java
+++ b/src/kundera-cassandra/cassandra-ds-driver/src/test/java/com/impetus/kundera/client/cassandra/crud/NativeQueryBindParametersTest.java
@@ -15,14 +15,10 @@
  ******************************************************************************/
 package com.impetus.kundera.client.cassandra.crud;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
@@ -32,28 +28,17 @@ import javax.persistence.TypedQuery;
 
 import junit.framework.Assert;
 
-import org.apache.cassandra.thrift.Compression;
-import org.apache.cassandra.thrift.ConsistencyLevel;
-import org.apache.cassandra.thrift.InvalidRequestException;
-import org.apache.cassandra.thrift.SchemaDisagreementException;
-import org.apache.cassandra.thrift.TimedOutException;
-import org.apache.cassandra.thrift.UnavailableException;
-import org.apache.thrift.TException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.impetus.client.cassandra.common.CassandraConstants;
-import com.impetus.client.cassandra.thrift.CQLTranslator;
 import com.impetus.client.crud.BaseTest;
-import com.impetus.client.crud.Group;
 import com.impetus.client.crud.Month;
 import com.impetus.client.crud.PersonCassandra;
 import com.impetus.client.crud.PersonCassandra.Day;
 import com.impetus.kundera.PersistenceProperties;
-import com.impetus.kundera.client.Client;
-import com.impetus.kundera.client.cassandra.dsdriver.DSClient;
 import com.impetus.kundera.client.cassandra.persistence.CassandraCli;
+
 
 /**
  * Test case to perform native queries with bind parameters

--- a/src/kundera-cassandra/cassandra-ds-driver/src/test/java/com/impetus/kundera/client/cassandra/crud/NativeQueryBindParametersTest.java
+++ b/src/kundera-cassandra/cassandra-ds-driver/src/test/java/com/impetus/kundera/client/cassandra/crud/NativeQueryBindParametersTest.java
@@ -1,0 +1,221 @@
+/*******************************************************************************
+ * * Copyright 2012 Impetus Infotech.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ ******************************************************************************/
+package com.impetus.kundera.client.cassandra.crud;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Persistence;
+import javax.persistence.Query;
+import javax.persistence.TypedQuery;
+
+import junit.framework.Assert;
+
+import org.apache.cassandra.thrift.Compression;
+import org.apache.cassandra.thrift.ConsistencyLevel;
+import org.apache.cassandra.thrift.InvalidRequestException;
+import org.apache.cassandra.thrift.SchemaDisagreementException;
+import org.apache.cassandra.thrift.TimedOutException;
+import org.apache.cassandra.thrift.UnavailableException;
+import org.apache.thrift.TException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.impetus.client.cassandra.common.CassandraConstants;
+import com.impetus.client.cassandra.thrift.CQLTranslator;
+import com.impetus.client.crud.BaseTest;
+import com.impetus.client.crud.Group;
+import com.impetus.client.crud.Month;
+import com.impetus.client.crud.PersonCassandra;
+import com.impetus.client.crud.PersonCassandra.Day;
+import com.impetus.kundera.PersistenceProperties;
+import com.impetus.kundera.client.Client;
+import com.impetus.kundera.client.cassandra.dsdriver.DSClient;
+import com.impetus.kundera.client.cassandra.persistence.CassandraCli;
+
+/**
+ * Test case to perform native queries with bind parameters
+ * 
+ * @author dev@antonyudin.com
+ */
+public class NativeQueryBindParametersTest extends BaseTest
+{
+    private static final String _PU = "cassandra_ds_pu";
+
+    /** The emf. */
+    private EntityManagerFactory emf;
+
+    /** The em. */
+    private EntityManager entityManager;
+
+    protected Map propertyMap = null;
+
+
+    /**
+     * Sets the up.
+     * 
+     * @throws Exception
+     *             the exception
+     */
+    @Before
+    public void setUp() throws Exception
+    {
+        
+        CassandraCli.cassandraSetUp();
+        System.setProperty("cassandra.start_native_transport", "true");
+
+        if (propertyMap == null)
+        {
+            propertyMap = new HashMap();
+            propertyMap.put(PersistenceProperties.KUNDERA_DDL_AUTO_PREPARE, "create");
+        }
+
+        emf = Persistence.createEntityManagerFactory(_PU, propertyMap);
+        entityManager = emf.createEntityManager();
+
+	    final List<PersonCassandra> entities = new ArrayList<>();
+
+	    for (int i = 0; i < 10; i++) {
+
+		final PersonCassandra entity = new PersonCassandra();
+		entity.setPersonId(Integer.toString(i));
+		entity.setPersonName("name" + i);
+		entity.setAge(10 + i);
+		entity.setDay(Day.thursday);
+		entity.setMonth(Month.APRIL);
+
+		entities.add(entity);
+	    }
+
+
+	    for (PersonCassandra entity: entities) {
+		    entityManager.persist(entity);
+	    }
+
+	    entityManager.flush();
+            entityManager.clear();
+
+    }
+
+    /**
+     * test native queries with named bind parameters
+     * 
+     * @throws Exception
+     *             the exception
+     */
+    @Test
+    public void onTestNativeQueriesNamedParametersInteger() throws Exception
+    {
+
+	    final List<Object[]> result = entityManager.createNativeQuery(
+		"SELECT " +
+		     "\"personId\", \"PERSON_NAME\", \"AGE\" " +
+		"FROM " +
+		     "\"PERSON\" " +
+	        "WHERE " +
+		     "\"AGE\" = :age " +
+		"ALLOW FILTERING"
+            ).setParameter("age", 10 + 3).getResultList();
+
+            Assert.assertNotNull(result);
+            Assert.assertEquals(result.size(), 1);
+            Assert.assertEquals(result.get(0)[0], "3");
+            Assert.assertEquals(result.get(0)[1], "name" + 3);
+            Assert.assertEquals(result.get(0)[2], 10 + 3);
+
+            entityManager.clear();
+    }
+
+
+    /**
+     * test native queries with named bind parameters
+     * 
+     * @throws Exception
+     *             the exception
+     */
+    @Test
+    public void onTestNativeQueriesNamedParametersString() throws Exception
+    {
+
+	    final List<Object[]> result = entityManager.createNativeQuery(
+		"SELECT " +
+		     "\"personId\", \"PERSON_NAME\" " +
+		"FROM " +
+		     "\"PERSON\" " +
+	        "WHERE " +
+		     "\"personId\" = :personId"
+            ).setParameter("personId", "3").getResultList();
+
+            Assert.assertNotNull(result);
+            Assert.assertEquals(result.size(), 1);
+            Assert.assertEquals(result.get(0)[0], "3");
+            Assert.assertEquals(result.get(0)[1], "name" + 3);
+
+            entityManager.clear();
+    }
+
+   /**
+     * test native queries with indexed bind parameters
+     * 
+     * @throws Exception
+     *             the exception
+     */
+    @Test
+    public void onTestNativeQueriesIndexedParametersString() throws Exception
+    {
+
+	    final List<Object[]> result = entityManager.createNativeQuery(
+		"SELECT " +
+		     "\"personId\", \"PERSON_NAME\" " +
+		"FROM " +
+		     "\"PERSON\" " +
+	        "WHERE " +
+		     "\"personId\" = ?"
+            ).setParameter(1, "2").getResultList();
+
+            Assert.assertNotNull(result);
+            Assert.assertEquals(result.size(), 1);
+            Assert.assertEquals(result.get(0)[0], "2");
+            Assert.assertEquals(result.get(0)[1], "name" + 2);
+
+            entityManager.clear();
+    }
+
+
+    /**
+     * Tear down.
+     * 
+     * @throws Exception
+     *             the exception
+     */
+    @After
+    public void tearDown() throws Exception
+    {
+        entityManager.close();
+        emf.close();
+        CassandraCli.dropKeySpace("KunderaExamples");
+    }
+
+}


### PR DESCRIPTION
Adding bind parameters support for cassandra native queries.
In the future parts of this code could be used to re-implement regular JPQL queries to use bind parameters.